### PR TITLE
Add responsive mobile menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,24 @@
 document.addEventListener('DOMContentLoaded', () => {
     const fixedNavContainer = document.getElementById('fixed-top-nav-container');
+    const mainNav = document.getElementById('mainNav');
+
+    if (fixedNavContainer && mainNav) {
+        const headerFlex = fixedNavContainer.querySelector('.flex-col');
+        if (headerFlex) {
+            const menuToggle = document.createElement('button');
+            menuToggle.className = 'menu-toggle sm:hidden p-2 text-gray-700';
+            menuToggle.innerHTML = '<i data-lucide="menu" class="w-6 h-6"></i>';
+            headerFlex.appendChild(menuToggle);
+            menuToggle.addEventListener('click', () => {
+                mainNav.classList.toggle('active');
+                menuToggle.innerHTML = mainNav.classList.contains('active')
+                    ? '<i data-lucide="x" class="w-6 h-6"></i>'
+                    : '<i data-lucide="menu" class="w-6 h-6"></i>';
+                if (lucide) lucide.createIcons();
+            });
+            if (lucide) lucide.createIcons();
+        }
+    }
     
     function adjustBodyPadding() {
         if (fixedNavContainer) {

--- a/style.css
+++ b/style.css
@@ -42,7 +42,13 @@ a:hover {
     color: #0072CE; 
 }
 #fixed-top-nav-container h1 a .text-gray-500:hover {
-     color: #0072CE !important; 
+     color: #0072CE !important;
+}
+
+/* Mobile menu toggle button */
+.menu-toggle {
+    display: none;
+    cursor: pointer;
 }
 
 
@@ -350,10 +356,16 @@ footer {
 }
 
 
-@media (max-width: 768px) { 
+@media (max-width: 768px) {
+    #mainNav {
+        display: none;
+    }
+    #mainNav.active {
+        display: block;
+    }
     #mainNav ul {
-        flex-direction: column; 
-        align-items: stretch; 
+        flex-direction: column;
+        align-items: stretch;
     }
     #mainNav .menu > a {
         justify-content: space-between; 
@@ -405,6 +417,10 @@ footer {
         width: 100%;
         margin-left: 0;
         margin-top: 0.5rem;
+    }
+
+    .menu-toggle {
+        display: block;
     }
 
 }


### PR DESCRIPTION
## Summary
- implement menu toggle button via JS
- hide nav and enable collapsible menu on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683eba197f808333823603d31621eb95