### PR TITLE
Optimize menu font and remove duplicates

### DIFF
--- a/script.js
+++ b/script.js
@@ -319,7 +319,7 @@ document.addEventListener('DOMContentLoaded', () => {
             koreanSpan.textContent = item.name_ko;
             textWrapper.appendChild(koreanSpan);
 
-            if (item.name_en) {
+            if (item.name_en && item.name_en !== item.name_ko) {
                 const englishSpan = document.createElement('span');
                 englishSpan.className = 'menu-english block text-xs opacity-80 mt-px';
                 englishSpan.textContent = `(${item.name_en})`;
@@ -329,7 +329,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
              a.className = 'block px-4 py-2 hover:bg-gray-100 text-sm text-gray-700 hover:text-slate-800';
              let linkText = item.name_ko;
-             if (item.name_en) {
+             if (item.name_en && item.name_en !== item.name_ko) {
                  linkText += ` <span class="text-xs opacity-80">(${item.name_en})</span>`;
              }
              a.innerHTML = linkText;

--- a/style.css
+++ b/style.css
@@ -66,11 +66,13 @@ a:hover {
 }
 
 #mainNav .menu > a {
-    min-height: 56px; 
-    line-height: 1.25; 
-    color: white; 
-    text-decoration: none; 
-    font-weight: 500; 
+    min-height: 56px;
+    line-height: 1.25;
+    color: white;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 16px;
+    padding: 8px 12px;
 }
 #mainNav .menu > a:hover,
 #mainNav .menu.active > a {
@@ -122,10 +124,10 @@ a:hover {
     display: flex; 
     justify-content: space-between; 
     align-items: center; 
-    padding: 0.5rem 1rem; 
-    color: #374151; 
+    padding: 5px 10px;
+    color: #374151;
     text-decoration: none;
-    font-size: 0.875rem; 
+    font-size: 14px;
     white-space: nowrap;
     transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out; 
 }
@@ -368,10 +370,10 @@ footer {
         align-items: stretch;
     }
     #mainNav .menu > a {
-        justify-content: space-between; 
-        text-align: left; 
-        font-size: 0.9rem;
-        padding-left: 1.5rem; 
+        justify-content: space-between;
+        text-align: left;
+        font-size: 16px;
+        padding-left: 1.5rem;
         padding-right: 1rem;
     }
     #mainNav .menu > a .menu-text-wrapper {


### PR DESCRIPTION
## Notes
- Adjusted font size and spacing for main and submenu items
- Hidden repeated English labels when they match Korean text

## Summary
- Set main menu font to `16px` with more padding
- Made submenu items `14px` and tightened spacing
- Removed duplicated English menu labels in `script.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683ebdcfb2bc8333b54e27a0fda0f9ef