### PR TITLE
Add responsive overlay for resource access

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,17 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const currentPage = window.location.pathname.split('/').pop();
     if (currentPage === 'lab_resources.html' || currentPage === 'resources.html') {
-        const correctPassword = 'bioprocess2025';
         const accessGranted = sessionStorage.getItem('labResourcesAccess') === 'true';
         if (!accessGranted) {
-            const inputPassword = prompt('자료실은 비밀번호가 필요합니다. 비밀번호를 입력해주세요.');
-            if (inputPassword === correctPassword) {
-                sessionStorage.setItem('labResourcesAccess', 'true');
-            } else {
-                alert('잘못된 패스워드입니다. 대소문자를 정확히 입력해주세요.');
-                window.location.href = 'index.html';
-                return;
-            }
+            showPasswordModal();
+            return;
         }
     }
 
@@ -44,13 +37,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function showPasswordModal(event) {
-        event.preventDefault();
+        if (event) event.preventDefault();
         const overlay = document.createElement('div');
         overlay.id = 'passwordOverlay';
         overlay.innerHTML = `
             <div class="gear"></div>
             <div class="password-container">
-                <p>자료실 비밀번호를 입력하세요 <span>(대소문자 구분)</span></p>
+                <p>비밀번호를 입력하세요 <span>(대소문자 구분)</span></p>
                 <input type="password" id="passwordInput" class="password-input" />
                 <div class="password-buttons mt-2">
                     <button id="passwordSubmit" class="mr-2 bg-blue-600 text-white px-3 py-1 rounded">확인</button>
@@ -77,7 +70,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function closeOverlay() {
         const overlay = document.getElementById('passwordOverlay');
         if (overlay) overlay.remove();
-        window.history.back();
+        if (window.history.length > 1) {
+            window.history.back();
+        } else {
+            window.location.href = 'index.html';
+        }
     }
 
     const menuStructure = [

--- a/style.css
+++ b/style.css
@@ -361,35 +361,43 @@ footer {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
     background: rgba(0, 0, 0, 0.9);
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     z-index: 9999;
-    flex-direction: column;
 }
 
 #passwordOverlay .gear {
-    width: 60px;
-    height: 60px;
-    border: 8px solid #ccc;
+    width: 15vw;
+    height: 15vw;
+    max-width: 80px;
+    max-height: 80px;
+    border: 8px solid #eaeaea;
     border-top-color: #3498db;
     border-radius: 50%;
-    animation: spin 1.5s linear infinite;
-    margin-bottom: 1.5rem;
+    animation: spin 1s linear infinite;
+    margin-bottom: 20px;
 }
 
 #passwordOverlay .password-container p {
     color: #fff;
     margin-bottom: 0.5rem;
+    text-align: center;
+    font-size: min(4vw, 16px);
 }
 
-#passwordOverlay .password-input {
-    padding: 0.5rem;
-    border-radius: 0.25rem;
-    border: 1px solid #ccc;
+#passwordOverlay .password-input,
+#passwordOverlay button {
+    padding: 8px;
+    font-size: min(4vw, 16px);
+    width: 60vw;
+    max-width: 300px;
+    box-sizing: border-box;
+    margin-top: 10px;
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary
- make the password overlay responsive using viewport units
- show the overlay on direct access to the resources page
- refine overlay text and allow closing back to previous page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ecdfdd6c48333a5b68b6f648d0130