### PR TITLE
Add collapsing breadcrumb nav

### DIFF
--- a/script.js
+++ b/script.js
@@ -507,6 +507,39 @@ document.addEventListener('DOMContentLoaded', () => {
     generateBreadcrumbs();
     if (lucide) lucide.createIcons();
 
+    const breadcrumbNav = document.getElementById('breadcrumbNav');
+    const mainContent = document.querySelector('main');
+
+    if (breadcrumbNav && mainContent) {
+        const sentinel = document.createElement('div');
+        sentinel.setAttribute('aria-hidden', 'true');
+        sentinel.style.height = '1px';
+        mainContent.parentNode.insertBefore(sentinel, mainContent);
+
+        function updateBreadcrumbHeight() {
+            const h = breadcrumbNav.scrollHeight;
+            breadcrumbNav.style.maxHeight = h + 'px';
+        }
+
+        updateBreadcrumbHeight();
+        window.addEventListener('resize', () => {
+            updateBreadcrumbHeight();
+            adjustBodyPadding();
+        });
+
+        breadcrumbNav.setAttribute('aria-expanded', 'true');
+
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                const show = entry.isIntersecting;
+                breadcrumbNav.classList.toggle('collapsed', !show);
+                breadcrumbNav.setAttribute('aria-expanded', show ? 'true' : 'false');
+                adjustBodyPadding();
+            });
+        });
+        observer.observe(sentinel);
+    }
+
     const resourcesMenuLink = document.querySelector('li[data-menu="resources"] > a');
     if (resourcesMenuLink) {
         resourcesMenuLink.addEventListener('click', showPasswordModal);

--- a/style.css
+++ b/style.css
@@ -157,7 +157,12 @@ a:hover {
 
 
 #breadcrumbNav {
-    border-bottom-color: rgba(229, 231, 235, 0.7); 
+    border-bottom-color: rgba(229, 231, 235, 0.7);
+    transition: max-height 0.3s ease;
+    overflow: hidden;
+}
+#breadcrumbNav.collapsed {
+    max-height: 0;
 }
 #breadcrumbNav ol {
     list-style: none;


### PR DESCRIPTION
## Summary
- auto-collapse breadcrumb bar when it overlaps with content
- animate breadcrumb height for smoother slide effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ece6b10948333b2bb8f4a62d39181