### PR TITLE
Create overview pages for menu categories

### DIFF
--- a/bp_eng_main.html
+++ b/bp_eng_main.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>세포배양공정 - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <header class="mb-10 border-b pb-6">
+                <h1 class="text-3xl md:text-4xl font-extrabold text-slate-800">세포배양공정 (Bioprocess Engineering)</h1>
+                <p class="text-lg text-gray-600 mt-2">Bioprocess Engineering</p>
+            </header>
+
+            <section class="mb-12">
+                <p class="text-base md:text-lg text-gray-700 leading-relaxed">
+                    세포배양공정은 바이오의약품 생산을 위한 핵심 기반 기술로, 업스트림부터 다운스트림까지 여러 단계의 공정을 포함합니다. 아래 항목을 통해 각 세부 분야의 내용을 살펴보세요.
+                </p>
+            </section>
+
+            <section>
+                <ul class="about-lab-list space-y-4 md:space-y-6">
+                    <li>
+                        <a href="bp_eng_intro_main.html" aria-label="세포배양공정이란">
+                            <h2 class="item-title"><i data-lucide="book-open"></i>세포배양공정이란?</h2>
+                            <p class="item-description">세포배양공정의 기본 개념과 역할을 소개합니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="bp_eng_upstream_main.html" aria-label="업스트림 공정">
+                            <h2 class="item-title"><i data-lucide="upload"></i>업스트림 공정</h2>
+                            <p class="item-description">세포주 개발과 배양 조건 최적화 등 초기 공정을 다룹니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="bp_eng_animal_cell_main.html" aria-label="동물세포배양">
+                            <h2 class="item-title"><i data-lucide="microscope"></i>동물세포배양</h2>
+                            <p class="item-description">CHO, HEK293 등 주요 세포주의 배양 기술을 살펴봅니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="bp_eng_downstream_main.html" aria-label="다운스트림 공정">
+                            <h2 class="item-title"><i data-lucide="download"></i>다운스트림 공정</h2>
+                            <p class="item-description">정제 및 회수 등 생산 후반 공정을 소개합니다.</p>
+                        </a>
+                    </li>
+                </ul>
+            </section>
+        </div>
+        
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/cfd_main.html
+++ b/cfd_main.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>전산유체역학 - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <header class="mb-10 border-b pb-6">
+                <h1 class="text-3xl md:text-4xl font-extrabold text-slate-800">전산유체역학 (Computational Fluid Dynamics)</h1>
+                <p class="text-lg text-gray-600 mt-2">Computational Fluid Dynamics</p>
+            </header>
+
+            <section class="mb-12">
+                <p class="text-base md:text-lg text-gray-700 leading-relaxed">
+                    전산유체역학(CFD)은 유체 거동을 정량적으로 예측하기 위한 강력한 도구입니다. 아래 항목에서 CFD 이론과 활용 사례를 살펴보세요.
+                </p>
+            </section>
+
+            <section>
+                <ul class="about-lab-list space-y-4 md:space-y-6">
+                    <li>
+                        <a href="cfd_theory.html" aria-label="CFD 이론">
+                            <h2 class="item-title"><i data-lucide="book-open"></i>CFD 이론</h2>
+                            <p class="item-description">CFD의 기본 이론과 해석 절차를 소개합니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="bioprocess_cfd.html" aria-label="Bioprocess CFD Simulation">
+                            <h2 class="item-title"><i data-lucide="activity"></i>Bioprocess CFD Simulation</h2>
+                            <p class="item-description">바이오공정 분야에서의 CFD 적용 사례를 살펴봅니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="software_index.html" aria-label="소프트웨어">
+                            <h2 class="item-title"><i data-lucide="cpu"></i>소프트웨어</h2>
+                            <p class="item-description">주요 CFD 소프트웨어와 사용 방법을 안내합니다.</p>
+                        </a>
+                    </li>
+                </ul>
+            </section>
+        </div>
+        
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/digital_twin_main.html
+++ b/digital_twin_main.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>디지털 트윈 기반 바이오공정 - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <header class="mb-10 border-b pb-6">
+                <h1 class="text-3xl md:text-4xl font-extrabold text-slate-800">디지털 트윈 기반 바이오공정 (Digital Twin Bioprocess)</h1>
+                <p class="text-lg text-gray-600 mt-2">Digital Twin Bioprocess</p>
+            </header>
+
+            <section class="mb-12">
+                <p class="text-base md:text-lg text-gray-700 leading-relaxed">
+                    디지털 트윈 기반 바이오공정은 실시간 모니터링과 모델링을 활용해 공정 최적화를 추구하는 연구 분야입니다. 하위 항목에서 세부 내용을 확인하세요.
+                </p>
+            </section>
+
+            <section>
+                <ul class="about-lab-list space-y-4 md:space-y-6">
+                    <li>
+                        <a href="digital_twin_overview_main.html" aria-label="연구 개요">
+                            <h2 class="item-title"><i data-lucide="book-open"></i>연구 개요</h2>
+                            <p class="item-description">디지털 트윈 연구의 개념과 필요성을 소개합니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="digital_twin_monitoring_ai_main.html" aria-label="실시간 모니터링 · AI 공정 제어">
+                            <h2 class="item-title"><i data-lucide="monitor"></i>실시간 모니터링 · AI 공정 제어</h2>
+                            <p class="item-description">데이터 분석과 AI 기반 공정 제어 기술을 다룹니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="digital_twin_trends_main.html" aria-label="최신 연구 동향">
+                            <h2 class="item-title"><i data-lucide="trending-up"></i>최신 연구 동향</h2>
+                            <p class="item-description">디지털 트윈 기술의 최근 연구 성과와 산업 적용 사례를 소개합니다.</p>
+                        </a>
+                    </li>
+                </ul>
+            </section>
+        </div>
+        
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/meta_eng_main.html
+++ b/meta_eng_main.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>시스템 대사공학 및 배지 최적화 - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <header class="mb-10 border-b pb-6">
+                <h1 class="text-3xl md:text-4xl font-extrabold text-slate-800">시스템 대사공학 및 배지 최적화 (Metabolic Engineering & Media Optimization)</h1>
+                <p class="text-lg text-gray-600 mt-2">Metabolic Engineering & Media Optimization</p>
+            </header>
+
+            <section class="mb-12">
+                <p class="text-base md:text-lg text-gray-700 leading-relaxed">
+                    대사공학과 배지 최적화 연구는 고효율 세포배양을 달성하기 위한 핵심 전략입니다. 아래 항목에서 세부 연구 내용을 확인해 보세요.
+                </p>
+            </section>
+
+            <section>
+                <ul class="about-lab-list space-y-4 md:space-y-6">
+                    <li>
+                        <a href="meta_eng_overview_main.html" aria-label="연구 개요">
+                            <h2 class="item-title"><i data-lucide="book-open"></i>연구 개요</h2>
+                            <p class="item-description">연구 배경과 기술적 접근 방법을 소개합니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="meta_eng_model_media_design_main.html" aria-label="모델 기반 배지 설계">
+                            <h2 class="item-title"><i data-lucide="beaker"></i>모델 기반 배지 설계</h2>
+                            <p class="item-description">대사 모델 기반의 배지 최적화와 자동화 시스템을 다룹니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="meta_eng_trends_main.html" aria-label="최신 연구 동향">
+                            <h2 class="item-title"><i data-lucide="trending-up"></i>최신 연구 동향</h2>
+                            <p class="item-description">관련 기술의 연구 성과와 산업 적용 사례를 살펴봅니다.</p>
+                        </a>
+                    </li>
+                </ul>
+            </section>
+        </div>
+        
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/proc_opt_main.html
+++ b/proc_opt_main.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>세포 배양 공정 최적화 - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <header class="mb-10 border-b pb-6">
+                <h1 class="text-3xl md:text-4xl font-extrabold text-slate-800">세포 배양 공정 최적화 (Process Optimization)</h1>
+                <p class="text-lg text-gray-600 mt-2">Process Optimization</p>
+            </header>
+
+            <section class="mb-12">
+                <p class="text-base md:text-lg text-gray-700 leading-relaxed">
+                    세포 배양 공정 최적화는 생산성 향상과 품질 확보를 위해 필수적인 연구 분야입니다. 아래 하위 항목에서 구체적인 접근 전략과 최신 동향을 확인할 수 있습니다.
+                </p>
+            </section>
+
+            <section>
+                <ul class="about-lab-list space-y-4 md:space-y-6">
+                    <li>
+                        <a href="proc_opt_overview_main.html" aria-label="연구 개요">
+                            <h2 class="item-title"><i data-lucide="book-open"></i>연구 개요</h2>
+                            <p class="item-description">공정 최적화의 필요성과 접근 전략을 소개합니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="proc_opt_dev_analytics_main.html" aria-label="배양 공정 설계 및 분석">
+                            <h2 class="item-title"><i data-lucide="settings"></i>배양 공정 설계 및 분석</h2>
+                            <p class="item-description">공정 조건 최적화와 데이터 기반 분석 방법을 다룹니다.</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="proc_opt_trends_main.html" aria-label="최신 연구 동향">
+                            <h2 class="item-title"><i data-lucide="trending-up"></i>최신 연구 동향</h2>
+                            <p class="item-description">관련 분야의 연구 성과와 산업 동향을 살펴봅니다.</p>
+                        </a>
+                    </li>
+                </ul>
+            </section>
+        </div>
+        
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
             { name_ko: '사진 갤러리', name_en: 'Photo Gallery', path: 'photo_gallery.html' }
         ] },
         {
-            id: 'bp_eng', name_ko: '세포배양공정', name_en: 'Bioprocess Engineering', path: '#',
+            id: 'bp_eng', name_ko: '세포배양공정', name_en: 'Bioprocess Engineering', path: 'bp_eng_main.html',
             children: [
                 { name_ko: '세포배양공정이란?', name_en: 'Introduction', path: 'bp_eng_intro_main.html', children: [
                     { name_ko: '개념 및 범위', name_en: 'Concept & Scope', path: 'bp_eng_intro_concept_scope.html' },
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ]
         },
         {
-            id: 'proc_opt', name_ko: '세포 배양 공정 최적화', name_en: 'Process Optimization', path: '#',
+            id: 'proc_opt', name_ko: '세포 배양 공정 최적화', name_en: 'Process Optimization', path: 'proc_opt_main.html',
             children: [
                 { name_ko: '연구 개요', name_en: 'Overview', path: 'proc_opt_overview_main.html', children: [
                     { name_ko: '연구 목적 및 필요성', name_en: 'Purpose & Necessity', path: 'proc_opt_overview_purpose_necessity.html' },
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ]
         },
         {
-            id: 'meta_eng', name_ko: '시스템 대사공학 및 배지 최적화', name_en: 'Metabolic Engineering & Media Optimization', path: '#',
+            id: 'meta_eng', name_ko: '시스템 대사공학 및 배지 최적화', name_en: 'Metabolic Engineering & Media Optimization', path: 'meta_eng_main.html',
             children: [
                 { name_ko: '연구 개요', name_en: 'Overview', path: 'meta_eng_overview_main.html', children: [
                     { name_ko: '연구 배경 및 목적', name_en: 'Background & Objectives', path: 'meta_eng_overview_background_objectives.html' },
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ]
         },
         {
-            id: 'cfd', name_ko: '전산유체역학', name_en: 'Computational Fluid Dynamics', path: '#',
+            id: 'cfd', name_ko: '전산유체역학', name_en: 'Computational Fluid Dynamics', path: 'cfd_main.html',
             children: [
                 { name_ko: 'CFD 이론', name_en: 'CFD Theory', path: 'cfd_theory.html', children: [
                     { name_ko: 'CFD 소개', name_en: 'CFD Introduction', path: 'cfd_introduction.html' },
@@ -224,7 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ]
         },
         {
-            id: 'digital_twin', name_ko: '디지털 트윈 기반 바이오공정', name_en: 'Digital Twin Bioprocess', path: '#',
+            id: 'digital_twin', name_ko: '디지털 트윈 기반 바이오공정', name_en: 'Digital Twin Bioprocess', path: 'digital_twin_main.html',
             children: [
                 { name_ko: '연구 개요', name_en: 'Overview', path: 'digital_twin_overview_main.html', children: [
                     { name_ko: '디지털 트윈 개념과 필요성', name_en: 'Concept & Necessity', path: 'digital_twin_overview_concept_necessity.html' },

--- a/search_index.json
+++ b/search_index.json
@@ -13,7 +13,15 @@
         "breadcrumb": ["홈", "연구실 소개"],
         "keywords": ["연구실 소개", "About Lab", "개요", "미션", "비전"],
         "content_snippet": "생물공학연구실 (Bioprocess Engineering Laboratory) 소개 페이지입니다. 연구실의 미션, 비전, 주요 활동 등을 안내합니다.",
-        "full_text": "생물공학연구실 소개. 연구 목표, 주요 연구 분야, 교수진, 연구팀 구성, 협력 네트워크, 연락처 등 연구실에 대한 전반적인 정보를 제공합니다. (본 페이지는 현재 준비 중입니다.)"
+    "full_text": "생물공학연구실 소개. 연구 목표, 주요 연구 분야, 교수진, 연구팀 구성, 협력 네트워크, 연락처 등 연구실에 대한 전반적인 정보를 제공합니다. (본 페이지는 현재 준비 중입니다.)"
+    },
+    {
+        "url": "bp_eng_main.html",
+        "title": "세포배양공정 - 생물공학연구실",
+        "breadcrumb": ["홈", "세포배양공정"],
+        "keywords": ["세포배양공정", "Bioprocess Engineering", "개요"],
+        "content_snippet": "세포배양공정 전반을 소개하고 하위 연구 주제로 이동할 수 있습니다.",
+        "full_text": "세포배양공정 메인 페이지. 업스트림과 다운스트림 등 세부 항목 안내."
     },
     {
         "url": "bp_eng_intro_main.html",
@@ -176,6 +184,14 @@
         "full_text": "최종 제형 및 충전 공정. (본 페이지는 현재 준비 중입니다.)"
     },
     {
+        "url": "proc_opt_main.html",
+        "title": "세포 배양 공정 최적화 - 생물공학연구실",
+        "breadcrumb": ["홈", "세포 배양 공정 최적화"],
+        "keywords": ["공정 최적화", "Process Optimization", "개요"],
+        "content_snippet": "세포 배양 공정 최적화 연구 전반을 소개하는 메인 페이지입니다.",
+        "full_text": "세포 배양 공정 최적화 메인 페이지. 공정 설계, 분석 및 최신 동향으로 이동할 수 있습니다."
+    },
+    {
         "url": "proc_opt_overview_main.html",
         "title": "연구 개요 - 세포 배양 공정 최적화",
         "breadcrumb": ["홈", "세포 배양 공정 최적화", "연구 개요"],
@@ -246,6 +262,14 @@
         "keywords": ["산업 동향", "학술 동향", "Industry Trends", "Academic Trends"],
         "content_snippet": "세포 배양 공정 최적화 기술의 산업계 적용 현황과 학계의 최신 연구 방향을 조망합니다.",
         "full_text": "세포 배양 공정 최적화 분야 산업 및 학술 동향. (본 페이지는 현재 준비 중입니다.)"
+    },
+    {
+        "url": "meta_eng_main.html",
+        "title": "시스템 대사공학 및 배지 최적화 - 생물공학연구실",
+        "breadcrumb": ["홈", "시스템 대사공학 및 배지 최적화"],
+        "keywords": ["대사공학", "배지 최적화", "Metabolic Engineering"],
+        "content_snippet": "시스템 대사공학과 배지 최적화 연구의 전반을 소개합니다.",
+        "full_text": "시스템 대사공학 및 배지 최적화 메인 페이지. 세부 연구 항목으로 이동할 수 있습니다."
     },
     {
         "url": "meta_eng_overview_main.html",
@@ -320,6 +344,14 @@
         "full_text": "시스템 대사공학 및 배지 최적화 기술의 산업계 적용 사례. (본 페이지는 현재 준비 중입니다.)"
     },
     {
+        "url": "cfd_main.html",
+        "title": "전산유체역학 - 생물공학연구실",
+        "breadcrumb": ["홈", "전산유체역학"],
+        "keywords": ["CFD", "Computational Fluid Dynamics", "개요"],
+        "content_snippet": "전산유체역학 전반과 관련 연구 주제로 이동할 수 있는 메인 페이지입니다.",
+        "full_text": "전산유체역학 메인 페이지. CFD 이론, Bioprocess CFD, 소프트웨어 소개로 이어집니다."
+    },
+    {
         "url": "cfd_theory.html",
         "title": "CFD 이론 - 전산유체역학",
         "breadcrumb": ["홈", "전산유체역학", "CFD 이론"],
@@ -342,6 +374,14 @@
         "keywords": ["소프트웨어", "CFD", "ANSYS Fluent", "OpenFOAM", "M-STAR CFD"],
         "content_snippet": "본 연구실에서 활용하거나 교육 자료를 제공하는 주요 전산 유체 역학(CFD) 및 관련 소프트웨어 목록입니다.",
         "full_text": "CFD 소프트웨어 메인 페이지. M-STAR CFD, Ansys Fluent, OpenFOAM 등 주요 소프트웨어 소개 및 상세 정보 링크 제공."
+    },
+    {
+        "url": "digital_twin_main.html",
+        "title": "디지털 트윈 기반 바이오공정 - 생물공학연구실",
+        "breadcrumb": ["홈", "디지털 트윈 기반 바이오공정"],
+        "keywords": ["디지털 트윈", "Digital Twin", "개요"],
+        "content_snippet": "디지털 트윈 기반 바이오공정 연구 전반을 소개합니다.",
+        "full_text": "디지털 트윈 기반 바이오공정 메인 페이지. 연구 개요, 실시간 모니터링, 최신 동향으로 이동할 수 있습니다."
     },
     {
         "url": "digital_twin_overview_main.html",


### PR DESCRIPTION
## Summary
- add dedicated pages for Bioprocess Engineering, Process Optimization, Metabolic Engineering, CFD, and Digital Twin
- update `script.js` menu paths to point to new pages
- include new pages in `search_index.json`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683ed2f32f6c8333b37021f4faea8bf0