### PR TITLE
Replace hamster loader with spinner

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         overlay.id = 'passwordOverlay';
         overlay.innerHTML = `
             <div id="overlayContent">
-                <div id="hamsterAnimation">🐹</div>
+                <div id="loadingSpinner" class="spinner"></div>
                 <p style="color:#fff; font-size:16px;">비밀번호를 입력하세요 <span>(대소문자 구분)</span></p>
                 <input type="password" id="passwordInput" class="password-input" placeholder="비밀번호 입력" />
                 <div class="password-buttons mt-2">

--- a/style.css
+++ b/style.css
@@ -383,10 +383,21 @@ footer {
     align-items: center;
 }
 
-#hamsterAnimation {
-    font-size: 64px;
+.password-buttons {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+
+#loadingSpinner {
+    width: 64px;
+    height: 64px;
+    border: 8px solid #f3f3f3;
+    border-top: 8px solid #3498db;
+    border-radius: 50%;
     margin-bottom: 20px;
-    animation: hamsterRun 0.8s linear infinite;
+    animation: spin 1s linear infinite;
 }
 
 #passwordOverlay .password-container p {
@@ -406,14 +417,16 @@ footer {
     border: none;
 }
 
-@keyframes hamsterRun {
-    0% { transform: translateX(40px); }
-    100% { transform: translateX(-40px); }
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }
 
 @media (max-width: 768px) {
-    #hamsterAnimation {
-        font-size: 60px;
+    #loadingSpinner {
+        width: 50px;
+        height: 50px;
+        border-width: 6px;
     }
     #passwordOverlay .password-input,
     #passwordOverlay button {


### PR DESCRIPTION
## Summary
- show spinner loader instead of hamster animation
- ensure password overlay buttons are centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683eef0c58cc8333b20fcb94563dd71a