### PR TITLE
Add header helper button

### DIFF
--- a/script.js
+++ b/script.js
@@ -834,6 +834,21 @@ if (sessionStorage.getItem("helperClosed")) {
     helperMenu.style.display = "none";
 }
 
+const searchContainerElem = document.querySelector('.search-container');
+if (searchContainerElem) {
+    const headerHelperBtn = document.createElement('div');
+    headerHelperBtn.id = 'header-helper-btn';
+    headerHelperBtn.innerHTML = '🐹 <span>뭐든 물어봐!</span>';
+    searchContainerElem.appendChild(headerHelperBtn);
+
+    headerHelperBtn.addEventListener('click', () => {
+        helperBtn.style.display = 'flex';
+        helperMenu.classList.remove('hidden');
+        helperMenu.style.display = 'block';
+        sessionStorage.removeItem('helperClosed');
+    });
+}
+
 helperBtn.addEventListener("click", () => {
     helperMenu.classList.toggle("hidden");
 });

--- a/style.css
+++ b/style.css
@@ -562,6 +562,18 @@ footer {
 #helper-menu.hidden {
   display: none;
 }
+#header-helper-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  background-color: #FFCA6C;
+  border-radius: 15px;
+  color: #3A3A3A;
+  font-weight: bold;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
 #helper-menu ul {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a search bar hamster button with styling
- allow reopening the helper overlay when it's been closed

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_683ef5ef51f08333b68712b0febd4c8f