### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,13 +16,16 @@ document.addEventListener('DOMContentLoaded', () => {
         if (headerFlex) {
             const menuToggle = document.createElement('button');
             menuToggle.className = 'menu-toggle sm:hidden p-2 text-gray-700';
+            menuToggle.setAttribute('aria-expanded', 'false');
+            menuToggle.setAttribute('aria-controls', 'mainNav');
             menuToggle.innerHTML = '<i data-lucide="menu" class="w-6 h-6"></i>';
             headerFlex.appendChild(menuToggle);
             menuToggle.addEventListener('click', () => {
-                mainNav.classList.toggle('active');
-                menuToggle.innerHTML = mainNav.classList.contains('active')
+                const expanded = mainNav.classList.toggle('active');
+                menuToggle.innerHTML = expanded
                     ? '<i data-lucide="x" class="w-6 h-6"></i>'
                     : '<i data-lucide="menu" class="w-6 h-6"></i>';
+                menuToggle.setAttribute('aria-expanded', expanded);
                 if (lucide) lucide.createIcons();
             });
             if (lucide) lucide.createIcons();
@@ -442,7 +445,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const GNB_DELAY = 0; 
 
             li.addEventListener('mouseenter', () => {
-                if (window.innerWidth > 768) { 
+                if (window.innerWidth > 768) {
                     if (level === 0) {
                         const allTopLevelLis = li.parentElement.querySelectorAll(':scope > li.menu-item-has-children');
                         allTopLevelLis.forEach(topLi => {
@@ -451,6 +454,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 const otherLink = topLi.querySelector('a');
                                 if (otherDropdown) {
                                     otherDropdown.style.display = 'none';
+                                    otherDropdown.classList.remove('open');
                                     if (otherLink) otherLink.setAttribute('aria-expanded', 'false');
                                 }
                             }
@@ -461,11 +465,13 @@ document.addEventListener('DOMContentLoaded', () => {
                             if (sibDrop !== ulDropdown) {
                                 sibDrop.style.display = 'none';
                                 const parentLink = sibDrop.parentElement.querySelector('a');
+                                sibDrop.classList.remove('open');
                                 if (parentLink) parentLink.setAttribute('aria-expanded', 'false');
                             }
                         });
                     }
                     ulDropdown.style.display = 'block';
+                    ulDropdown.classList.add('open');
                     a.setAttribute('aria-expanded', 'true');
                 }
             });
@@ -475,6 +481,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     setTimeout(() => {
                         if (!li.matches(':hover')) {
                             ulDropdown.style.display = 'none';
+                            ulDropdown.classList.remove('open');
                             a.setAttribute('aria-expanded', 'false');
                         }
                     }, GNB_DELAY);
@@ -484,7 +491,7 @@ document.addEventListener('DOMContentLoaded', () => {
             a.addEventListener('click', (event) => {
                 if (item.path === '#' || (window.innerWidth <= 768 && item.children && item.children.length > 0)) {
                     event.preventDefault();
-                    const currentlyOpen = ulDropdown.style.display === 'block';
+                    const currentlyOpen = ulDropdown.classList.contains('open');
                     if (level === 0 && window.innerWidth <= 768) {
                         const allTopLevelLis = li.parentElement.querySelectorAll(':scope > li.menu-item-has-children');
                         allTopLevelLis.forEach(topLi => {
@@ -492,13 +499,13 @@ document.addEventListener('DOMContentLoaded', () => {
                                 const otherDropdown = topLi.querySelector('.dropdown-menu');
                                 const otherLink = topLi.querySelector('a');
                                 if (otherDropdown) {
-                                    otherDropdown.style.display = 'none';
+                                    otherDropdown.classList.remove('open');
                                     if (otherLink) otherLink.setAttribute('aria-expanded', 'false');
                                 }
                             }
                         });
                     }
-                    ulDropdown.style.display = currentlyOpen ? 'none' : 'block';
+                    ulDropdown.classList.toggle('open', !currentlyOpen);
                     a.setAttribute('aria-expanded', currentlyOpen ? 'false' : 'true');
                 }
             });

--- a/style.css
+++ b/style.css
@@ -95,11 +95,12 @@ a:hover {
 }
 
 #mainNav .menu.menu-item-has-children > a .lucide-chevron-down {
-    margin-left: 0.35rem; 
-    width: 0.875rem; 
+    margin-left: 0.35rem;
+    width: 0.875rem;
     height: 0.875rem;
-    color: #cbd5e1; 
-    flex-shrink: 0; 
+    color: #cbd5e1;
+    flex-shrink: 0;
+    transition: transform 0.3s ease;
 }
 
 
@@ -107,14 +108,18 @@ a:hover {
     display: none;
     position: absolute;
     left: 0;
-    top: 100%; 
+    top: 100%;
     background-color: #ffffff; 
     min-width: 240px; 
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 100; 
     border-radius: 0 0 0.375rem 0.375rem; 
-    padding: 0.5rem 0; 
-    border: 1px solid #e5e7eb; 
+    padding: 0.5rem 0;
+    border: 1px solid #e5e7eb;
+}
+
+#mainNav .dropdown-menu.open {
+    display: block;
 }
 
 #mainNav .dropdown-menu li {
@@ -151,9 +156,18 @@ a:hover {
 
 #mainNav .dropdown-menu .menu-item-has-children > a .lucide-chevron-right {
     margin-left: 0.5rem;
-    width: 1rem; 
-    height: 1rem; 
-    color: #9ca3af; 
+    width: 1rem;
+    height: 1rem;
+    color: #9ca3af;
+    transition: transform 0.3s ease;
+}
+
+#mainNav a[aria-expanded="true"] .lucide-chevron-down {
+    transform: rotate(180deg);
+}
+
+#mainNav a[aria-expanded="true"] .lucide-chevron-right {
+    transform: rotate(90deg);
 }
 
 
@@ -468,17 +482,21 @@ footer {
     }
 
     #mainNav .dropdown-menu {
-        position: static; 
+        position: static;
         width: 100%;
         box-shadow: none;
         border-left: 3px solid #0056a4;
-        border-top: 1px solid #475569; 
+        border-top: 1px solid #475569;
         border-right: none;
         border-bottom: none;
         border-radius: 0;
         margin-top:0;
-        padding-left: 0; 
-        background-color: #334155; 
+        padding-left: 0;
+        background-color: #334155;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease-in-out;
+        display: block;
     }
     #mainNav .dropdown-menu li a {
         color: #e2e8f0;
@@ -488,19 +506,23 @@ footer {
         background-color: #1e293b; 
     }
 
-    #mainNav .dropdown-menu .dropdown-menu { 
+    #mainNav .dropdown-menu .dropdown-menu {
         position: static;
         margin-left: 0;
-        padding-left: 0; 
-        background-color: #293548; 
-        border-left: 3px solid #004A99; 
+        padding-left: 0;
+        background-color: #293548;
+        border-left: 3px solid #004A99;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease-in-out;
     }
     #mainNav .dropdown-menu .dropdown-menu li a {
         padding-left: 3.5rem;
     }
 
-    #mainNav a[aria-expanded="true"] + .dropdown-menu {
-        display: block;
+    #mainNav a[aria-expanded="true"] + .dropdown-menu,
+    #mainNav .dropdown-menu.open {
+        max-height: 1000px;
     }
 
     #fixed-top-nav-container .container .flex-col { 


### PR DESCRIPTION
## Summary
- animate submenu dropdowns for mobile
- rotate menu arrows when expanded
- support open class for submenu transitions
- make mobile menu button accessible
- toggle submenu display with `.open` class

## Testing
- `node -v`
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_683ef6afd6148333af3bcb0eb7c2ebbb