### PR TITLE
Fix mobile submenus

### DIFF
--- a/script.js
+++ b/script.js
@@ -489,7 +489,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             
             a.addEventListener('click', (event) => {
-                if (item.path === '#' || (window.innerWidth <= 768 && item.children && item.children.length > 0)) {
+                if (item.path === '#' || (window.innerWidth <= 768 && level === 0 && item.children && item.children.length > 0)) {
                     event.preventDefault();
                     const currentlyOpen = ulDropdown.classList.contains('open');
                     if (level === 0 && window.innerWidth <= 768) {

--- a/style.css
+++ b/style.css
@@ -515,6 +515,11 @@ footer {
         max-height: 0;
         overflow: hidden;
         transition: max-height 0.3s ease-in-out;
+        display: none;
+        pointer-events: none;
+    }
+    #mainNav .dropdown-menu .menu-item-has-children > a .lucide-chevron-right {
+        display: none;
     }
     #mainNav .dropdown-menu .dropdown-menu li a {
         padding-left: 3.5rem;


### PR DESCRIPTION
## Summary
- don't toggle nested menus on mobile
- hide nested submenus and arrows on small screens

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_683f081a686483339995be9c60ddc51f