### PR TITLE
Add video background to main hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,10 @@
 
     <main>
         <section class="hero-section relative flex items-center justify-center text-white overflow-hidden min-h-[calc(100vh-120px)] sm:min-h-[calc(100vh-100px)]">
-            <div class="absolute inset-0 z-0 hero-bg-gradient"></div>
+            <video autoplay muted loop playsinline id="bgVideo">
+                <source src="20250603_2258_Digital Twin Bioprocess_simple_compose_01jwv1bhfnfa6b14pv63hxc0p7.mp4" type="video/mp4">
+            </video>
+            <div class="absolute inset-0 z-0 hero-bg-gradient opacity-60"></div>
             <div class="absolute inset-0 z-0 hero-bg-pattern opacity-10"></div>
 
             <div class="relative z-10 container mx-auto px-6 text-center py-12">

--- a/style.css
+++ b/style.css
@@ -206,8 +206,24 @@ a:hover {
 
 .hero-section {
 }
+.hero-section #bgVideo {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: -1;
+}
+
+@media (max-width: 768px) {
+  .hero-section #bgVideo {
+    height: auto;
+    min-height: 100%;
+  }
+}
 .hero-bg-gradient {
-    background: linear-gradient(135deg, #0072CE 0%, #3b82f6 50%, #60a5fa 100%); 
+    background: linear-gradient(135deg, #0072CE 0%, #3b82f6 50%, #60a5fa 100%);
 }
 .hero-bg-pattern { 
     background-image: 


### PR DESCRIPTION
## Summary
- embed `20250603_2258_Digital Twin Bioprocess_simple_compose_01jwv1bhfnfa6b14pv63hxc0p7.mp4` as hero background
- apply semi-transparent gradient overlay
- style video for full screen coverage with responsive tweaks

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f1801ff008333b8365fd8bc1b4f4d