### PR TITLE
Improve hero text readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,10 @@
             <div class="absolute inset-0 z-0 hero-bg-pattern opacity-10"></div>
 
             <div class="relative z-10 container mx-auto px-6 text-center py-12">
-                <h2 class="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 leading-tight shadow-text">
+                <h2 class="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 leading-tight shadow-text hero-highlight">
                     차세대 바이오공정 혁신을 위한 융합 연구 선도
                 </h2>
-                <p class="text-lg sm:text-xl md:text-2xl mb-10 max-w-3xl mx-auto font-light shadow-text-sm">
+                <p class="text-lg sm:text-xl md:text-2xl mb-10 max-w-3xl mx-auto font-light shadow-text-sm hero-highlight">
                     데이터 과학과 공학적 모델링, 시스템 생물학의 통합으로 지속 가능한 바이오공정 솔루션을 선도합니다.
                 </p>
                 <a href="about_lab.html" class="bg-white hover:bg-gray-100 text-[#0072CE] font-semibold py-3 px-10 rounded-lg text-lg transition duration-300 ease-in-out transform hover:scale-105 shadow-lg hover:shadow-xl">

--- a/style.css
+++ b/style.css
@@ -239,6 +239,21 @@ a:hover {
     text-shadow: 0px 1px 3px rgba(0, 0, 0, 0.25);
 }
 
+/* Highlight style for hero section text */
+.hero-highlight {
+    color: #ffffff;
+    background-color: rgba(0, 114, 206, 0.7);
+    padding: 0.5rem 1rem;
+    display: inline-block;
+    border-radius: 0.375rem;
+}
+
+@media (max-width: 768px) {
+  .hero-highlight {
+    padding: 0.4rem 0.75rem;
+  }
+}
+
 
 .research-card {
     transition: transform 0.3s ease-out, box-shadow 0.3s ease-out;


### PR DESCRIPTION
## Summary
- highlight hero heading and subheading with blue background
- add responsive styles for hero text

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_683f1f05a9f883338644fed84ff13ce6