### PR TITLE
Fix helper button position on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -826,9 +826,9 @@ td {
     margin-left: auto;
   }
   #header-helper-btn {
-    position: absolute;
-    right: 10px;
-    top: -40px;
-    margin-left: 0;
+    position: relative;
+    right: auto;
+    top: auto;
+    margin-left: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- adjust CSS so hamster helper button sits naturally to the right of the search bar on large screens

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_683f2af4e3048333a90d1660c4875829