### PR TITLE
Align header helper button on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -710,6 +710,7 @@ footer {
   user-select: none;
 }
 
+
 .hamster-icon {
   font-size: 2em;
 }
@@ -828,6 +829,9 @@ td {
   position: relative;
 }
 @media (min-width: 1024px) {
+  #fixed-top-nav-container .header-container {
+    justify-content: flex-start;
+  }
   #fixed-top-nav-container .search-container {
     margin-left: auto;
   }
@@ -836,5 +840,8 @@ td {
     right: auto;
     top: auto;
     margin-left: 0.5rem;
+    padding: 0.5rem 1rem;
+    line-height: 1;
+    height: 2rem;
   }
 }


### PR DESCRIPTION
## Summary
- adjust desktop header layout so helper button sits next to the search bar
- ensure helper button matches search bar height on large screens

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_683f3097535883339f72f3dd25ccec8e