### PR TITLE
Fix helper menu toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -906,7 +906,8 @@ if (headerHelperBtn && !headerHelperBtn.dataset.helperBound) {
 
 if (!helperBtn.dataset.helperBound) {
     helperBtn.addEventListener("click", () => {
-        helperMenu.classList.toggle("hidden");
+        const nowHidden = helperMenu.classList.toggle("hidden");
+        helperMenu.style.display = nowHidden ? 'none' : 'block';
     });
 
     helperMenu.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- ensure floating helper button toggles menu visibility by adjusting `display` style

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_683f7e1b5c1883338e185550f9a3b9d6