### PR TITLE
Add partial English translation support

### DIFF
--- a/en.json
+++ b/en.json
@@ -1,5 +1,8 @@
 {
   "title": "Bioprocess Engineering Laboratory",
   "welcomeMessage": "Leading Convergent Research for Next-Generation Bioprocess Innovation",
-  "description": "We lead sustainable bioprocess solutions through the integration of data science, engineering modeling, and systems biology."
+  "description": "We lead sustainable bioprocess solutions through the integration of data science, engineering modeling, and systems biology.",
+  "searchInput_placeholder": "Search...",
+  "searchButton": "Search",
+  "searchResultsHeading": "Search Results"
 }

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
         </section>
         
         <div id="searchResultsContainer" class="container mx-auto px-6 my-8 p-6 bg-white rounded-lg shadow-lg hidden">
-            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <h2 id="searchResultsHeading" class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
             <div id="searchResultsList" class="space-y-4"></div>
         </div>
     </main>

--- a/script.js
+++ b/script.js
@@ -141,6 +141,10 @@ document.addEventListener('DOMContentLoaded', () => {
         Object.keys(texts).forEach(key => {
             if (key === 'title') {
                 document.title = texts[key];
+            } else if (key.endsWith('_placeholder')) {
+                const id = key.replace('_placeholder', '');
+                const element = document.getElementById(id);
+                if (element) element.placeholder = texts[key];
             } else {
                 const element = document.getElementById(key);
                 if (element) element.textContent = texts[key];
@@ -165,6 +169,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (!(key in defaultTexts)) {
                     if (key === 'title') {
                         defaultTexts[key] = document.title;
+                    } else if (key.endsWith('_placeholder')) {
+                        const id = key.replace('_placeholder', '');
+                        const el = document.getElementById(id);
+                        if (el) defaultTexts[key] = el.placeholder || '';
                     } else {
                         const el = document.getElementById(key);
                         if (el) defaultTexts[key] = el.textContent || '';


### PR DESCRIPTION
## Summary
- update translation loader to handle placeholder text
- translate search-related text and add heading IDs
- extend English translations for search UI

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f86f9ec488333ba4cb351389ba803