### PR TITLE
Enable Chinese language option

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             langSelect.className = 'ml-2 p-1 border rounded text-sm';
             langSelect.setAttribute('aria-label', 'Language selector');
             langSelect.setAttribute('role', 'combobox');
-            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option>';
+            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option>';
             headerFlex.appendChild(langSelect);
             langSelect.addEventListener('change', () => {
                 loadLanguage(langSelect.value);

--- a/zh.json
+++ b/zh.json
@@ -1,0 +1,8 @@
+{
+  "title": "生物工艺工程实验室",
+  "welcomeMessage": "引领下一代生物工艺创新的融合研究",
+  "description": "我们通过整合数据科学、工程建模和系统生物学，引领可持续的生物工艺解决方案。",
+  "searchInput_placeholder": "搜索...",
+  "searchButton": "搜索",
+  "searchResultsHeading": "搜索结果"
+}


### PR DESCRIPTION
## Summary
- support Chinese translations via `zh.json`
- include Chinese option in language switcher

## Testing
- `node --version`
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_683f89ae2f8883339d65e0958fe39339