### PR TITLE
Add Japanese language support

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -1,0 +1,8 @@
+{
+  "title": "バイオプロセス工学研究室",
+  "welcomeMessage": "次世代バイオプロセス革新のための融合研究を先導",
+  "description": "データサイエンス、工学的モデリング、システム生物学の統合によって持続可能なバイオプロセスソリューションをリードします。",
+  "searchInput_placeholder": "検索...",
+  "searchButton": "検索",
+  "searchResultsHeading": "検索結果"
+}

--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             langSelect.className = 'ml-2 p-1 border rounded text-sm';
             langSelect.setAttribute('aria-label', 'Language selector');
             langSelect.setAttribute('role', 'combobox');
-            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option>';
+            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="ja">日本語</option>';
             headerFlex.appendChild(langSelect);
             langSelect.addEventListener('change', () => {
                 loadLanguage(langSelect.value);


### PR DESCRIPTION
## Summary
- provide Japanese translations in `ja.json`
- add Japanese option to the language selector in `script.js`

## Testing
- `cat ja.json`


------
https://chatgpt.com/codex/tasks/task_e_683f8a0f3b408333b64d1374f56dadda