### PR TITLE
Add German language support

### DIFF
--- a/de.json
+++ b/de.json
@@ -1,0 +1,8 @@
+{
+  "title": "Labor f\u00fcr Bioprozessingenieurwesen",
+  "welcomeMessage": "F\u00fchrende konvergente Forschung f\u00fcr Bioprozessinnovationen der n\u00e4chsten Generation",
+  "description": "Wir f\u00fchren nachhaltige Bioprozessl\u00f6sungen durch die Integration von Data Science, ingenieurwissenschaftlicher Modellierung und Systembiologie.",
+  "searchInput_placeholder": "Suchen...",
+  "searchButton": "Suchen",
+  "searchResultsHeading": "Suchergebnisse"
+}

--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             langSelect.className = 'ml-2 p-1 border rounded text-sm';
             langSelect.setAttribute('aria-label', 'Language selector');
             langSelect.setAttribute('role', 'combobox');
-            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option>';
+            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option><option value="de">Deutsch</option>';
             headerFlex.appendChild(langSelect);
             langSelect.addEventListener('change', () => {
                 loadLanguage(langSelect.value);


### PR DESCRIPTION
## Summary
- add German translations in `de.json`
- include `Deutsch` option in language switcher

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_683f8a9483688333a46b805e8fce232e