### PR TITLE
Add French translations

### DIFF
--- a/fr.json
+++ b/fr.json
@@ -1,0 +1,8 @@
+{
+  "title": "Laboratoire de G\u00e9nie Bioproc\u00e9d\u00e9",
+  "welcomeMessage": "Chef de file de la recherche convergente pour l'innovation des bioproc\u00e9d\u00e9s de prochaine g\u00e9n\u00e9ration",
+  "description": "Nous proposons des solutions bioproc\u00e9d\u00e9s durables par l'int\u00e9gration de la science des donn\u00e9es, de la mod\u00e9lisation de l'ing\u00e9nierie et de la biologie des syst\u00e8mes.",
+  "searchInput_placeholder": "Rechercher...",
+  "searchButton": "Rechercher",
+  "searchResultsHeading": "R\u00e9sultats de recherche"
+}

--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             langSelect.className = 'ml-2 p-1 border rounded text-sm';
             langSelect.setAttribute('aria-label', 'Language selector');
             langSelect.setAttribute('role', 'combobox');
-            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option>';
+            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option><option value="fr">Français</option>';
             headerFlex.appendChild(langSelect);
             langSelect.addEventListener('change', () => {
                 loadLanguage(langSelect.value);


### PR DESCRIPTION
## Summary
- add French language JSON translation
- include French option in language dropdown

## Testing
- `node --check script.js`
- `node -e "JSON.parse(require('fs').readFileSync('fr.json', 'utf8')); console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_683f8ae0065c8333a46e8dd5b675f8e3