### PR TITLE
Remove unused languages from dropdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             langSelect.className = 'ml-2 p-1 border rounded text-sm';
             langSelect.setAttribute('aria-label', 'Language selector');
             langSelect.setAttribute('role', 'combobox');
-            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option><option value="de">Deutsch</option>';
+            langSelect.innerHTML = '<option value="default">기본</option><option value="en">English</option><option value="zh">中文</option>';
             headerFlex.appendChild(langSelect);
             langSelect.addEventListener('change', () => {
                 loadLanguage(langSelect.value);


### PR DESCRIPTION
## Summary
- simplify the language switcher dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f99ce5e8c8333986c63e0a85d89c8