### PR TITLE
Fix helper menu on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -860,4 +860,17 @@ td {
     right: 15px;
     padding: 8px 12px;
   }
+  #helper-btn {
+    top: auto !important;
+    bottom: 16px;
+    right: 16px;
+  }
+  #helper-menu {
+    top: auto !important;
+    bottom: 72px;
+    right: 16px;
+    max-height: 55vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
 }


### PR DESCRIPTION
## Summary
- adjust helper menu offset for mobile screens

## Testing
- `node generate_search_index.js`


------
https://chatgpt.com/codex/tasks/task_e_6845882083308333a61bc2cca6e43279