### PR TITLE
Fix helper menu on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -860,4 +860,18 @@ td {
     right: 15px;
     padding: 8px 12px;
   }
+  #helper-btn {
+    top: auto !important;
+    bottom: 16px;
+    right: 16px;
+  }
+  #helper-menu {
+    top: 180px;
+    bottom: auto;
+    right: 16px;
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
 }
+


### PR DESCRIPTION
## Summary
- adjust helper menu offset for mobile screens
- resolve merge conflict between right offset and height limit

## Testing
- `node generate_search_index.js`


------
https://chatgpt.com/codex/tasks/task_e_6845882083308333a61bc2cca6e43279