### PR TITLE
Fix Useful Tools page layout

### DIFF
--- a/search_index.json
+++ b/search_index.json
@@ -2657,6 +2657,6 @@
             "생물공학연구실"
         ],
         "content_snippet": "실험·모델링·데이터 분석을 간소화하는 계산기 모음입니다.",
-        "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! 유용한 도구 (Useful Tools) 실험·모델링·데이터 분석을 간소화하는 계산기 모음입니다. CELBIC system angle &amp; RPM setting CELBIC 시스템 각도·RPM 계산 CFD 변수들의 통계적 값 처리 시간 평활·RMS·PDF 계산 툴 RMSE 계산기 예측 vs 실측 오차(RMSE) 즉시 계산 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다. @media (max-width: 768px) { h1.text-3xl { font-size: 1.75rem; } }"
+        "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! 유용한 도구 (Useful Tools) 실험·모델링·데이터 분석을 간소화하는 계산기 모음입니다. CELBIC system angle &amp; RPM setting CFD 변수들의 통계적 값 처리 RMSE 계산기 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다. @media (max-width: 768px) { h1.text-3xl { font-size: 1.75rem; } }"
     }
 ]

--- a/useful-tools/index.html
+++ b/useful-tools/index.html
@@ -52,31 +52,24 @@
                         <a href="#" role="button" aria-label="CELBIC system angle & RPM setting" class="block bg-slate-50 p-6 rounded-md hover:bg-gray-100 transition-colors text-center h-full">
                             <i data-lucide="settings" class="h-8 w-8 mx-auto mb-3" aria-hidden="true"></i>
                             <span class="font-medium text-[#0072CE]">CELBIC system angle &amp; RPM setting</span>
-                            <p class="text-sm text-gray-600 mt-1">CELBIC 시스템 각도·RPM 계산</p>
                         </a>
                     </li>
                     <li>
                         <a href="#" role="button" aria-label="CFD statistical post processing" class="block bg-slate-50 p-6 rounded-md hover:bg-gray-100 transition-colors text-center h-full">
                             <i data-lucide="bar-chart-2" class="h-8 w-8 mx-auto mb-3" aria-hidden="true"></i>
                             <span class="font-medium text-[#0072CE]">CFD 변수들의 통계적 값 처리</span>
-                            <p class="text-sm text-gray-600 mt-1">시간 평활·RMS·PDF 계산 툴</p>
                         </a>
                     </li>
                     <li>
                         <a href="#" role="button" aria-label="RMSE calculator" class="block bg-slate-50 p-6 rounded-md hover:bg-gray-100 transition-colors text-center h-full">
                             <i data-lucide="calculator" class="h-8 w-8 mx-auto mb-3" aria-hidden="true"></i>
                             <span class="font-medium text-[#0072CE]">RMSE 계산기</span>
-                            <p class="text-sm text-gray-600 mt-1">예측 vs 실측 오차(RMSE) 즉시 계산</p>
                         </a>
                     </li>
                 </ul>
             </section>
         </div>
 
-        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
-            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
-            <div id="searchResultsList" class="space-y-4"></div>
-        </div>
     </main>
 
     <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">


### PR DESCRIPTION
## Summary
- remove unused search results section from Useful Tools page
- trim helper text from tool cards
- regenerate search index

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_684595e9418c83339ea0688dfef903f3