### PR TITLE
Mobile helper panel tweaks

### DIFF
--- a/style.css
+++ b/style.css
@@ -734,6 +734,18 @@ footer {
   animation: attention 1s ease-in-out;
 }
 
+/* === helper-panel|MOBILE_FIX_START === */
+@media (max-width: 768px) {
+  #helper-btn {
+    bottom: 100px;
+  }
+  .helper-panel,
+  .helper-panel * {
+    font-size: 0.85rem;
+  }
+}
+/* === helper-panel|MOBILE_FIX_END === */
+
 /* ===== Custom styles for responsive updates ===== */
 h1.main-title {
   font-size: 3rem;


### PR DESCRIPTION
## Summary
- make the helper button sit 100px above bottom on small screens
- shrink the helper panel text to reduce height on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845b456109083338ad69ece9c7f9f89