### PR TITLE
Adjust helper menu height on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -679,6 +679,15 @@ footer {
   font-size: 16px;
 }
 
+/* === helper-panel|MOBILE_FIX_START === */
+@media (max-width: 768px) {
+  #helper-menu {
+    max-height: 200px;
+    overflow-y: auto;
+  }
+}
+/* === helper-panel|MOBILE_FIX_END === */
+
 .animation-section {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary
- on screens <=768px, limit `#helper-menu` to half height
- ensure vertical scrolling is enabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b8b2c19c8333a54f2989eda51ca2