### PR TITLE
Add Useful Tools pages and nav

### DIFF
--- a/celbic_angle_rpm.html
+++ b/celbic_angle_rpm.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CELBIC system angle & RPM setting - 유용한 도구 | 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="header-container flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+                <div id="header-helper-btn" class="helper-btn" aria-label="도우미 열기">
+                    <span class="hamster-icon">🐹</span>
+                    <span class="helper-text">뭐든 물어봐!</span>
+                </div>
+            </div>
+        </div>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <section class="container my-5">
+                <h1 class="display-6 fw-bold">CELBIC system angle &amp; RPM setting</h1>
+                <p class="lead">내용 추가 예정(Coming soon).</p>
+            </section>
+        </div>
+
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CFD 변수들의 통계적 값 처리 - 유용한 도구 | 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="header-container flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+                <div id="header-helper-btn" class="helper-btn" aria-label="도우미 열기">
+                    <span class="hamster-icon">🐹</span>
+                    <span class="helper-text">뭐든 물어봐!</span>
+                </div>
+            </div>
+        </div>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <section class="container my-5">
+                <h1 class="display-6 fw-bold">CFD 변수들의 통계적 값 처리</h1>
+                <p class="lead">내용 추가 예정(Coming soon).</p>
+            </section>
+        </div>
+
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/rmse_calculator.html
+++ b/rmse_calculator.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RMSE 계산기 - 유용한 도구 | 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="header-container flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+                <div id="header-helper-btn" class="helper-btn" aria-label="도우미 열기">
+                    <span class="hamster-icon">🐹</span>
+                    <span class="helper-text">뭐든 물어봐!</span>
+                </div>
+            </div>
+        </div>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <section class="container my-5">
+                <h1 class="display-6 fw-bold">RMSE 계산기</h1>
+                <p class="lead">내용 추가 예정(Coming soon).</p>
+            </section>
+        </div>
+
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -354,6 +354,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 ]}
             ]
         },
+        {
+            id: 'useful_tools', name_ko: '유용한 도구', name_en: 'Useful Tools', path: 'useful_tools.html',
+            children: [
+                { name_ko: 'CELBIC system angle & RPM setting', name_en: 'CELBIC system angle & RPM setting', path: 'celbic_angle_rpm.html' },
+                { name_ko: 'CFD 변수들의 통계적 값 처리', name_en: 'CFD Statistics', path: 'cfd_statistics.html' },
+                { name_ko: 'RMSE 계산기', name_en: 'RMSE Calculator', path: 'rmse_calculator.html' }
+            ]
+        },
         { id: 'resources', name_ko: '자료실', name_en: 'Resources', path: 'lab_resources.html' }
     ];
     

--- a/search_index.json
+++ b/search_index.json
@@ -745,6 +745,27 @@
         "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! 공정 스케일업·다운 (Process Scale‑up & Scale‑down) 실험실 규모에서 상업 생산 규모로, 또는 그 반대로 공정 규모를 변경하는 스케일업 및 스케일다운 전략과 고려사항을 다룹니다. 콘텐츠 준비 중 이 페이지의 상세 내용은 현재 준비 중에 있습니다. 곧 업데이트될 예정입니다. 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
     },
     {
+        "url": "celbic_angle_rpm.html",
+        "title": "CELBIC system angle & RPM setting - 유용한 도구 | 생물공학연구실",
+        "breadcrumb": [
+            "홈",
+            "유용한 도구",
+            "CELBIC system angle & RPM setting"
+        ],
+        "keywords": [
+            "CELBIC",
+            "system",
+            "angle",
+            "RPM",
+            "setting",
+            "유용한",
+            "도구",
+            "생물공학연구실"
+        ],
+        "content_snippet": "내용 추가 예정(Coming soon).",
+        "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! CELBIC system angle &amp; RPM setting 내용 추가 예정(Coming soon). 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
+    },
+    {
         "url": "cfd_core_theory.html",
         "title": "CFD 핵심 이론 - 생물공학연구실",
         "breadcrumb": [
@@ -1087,6 +1108,27 @@
         ],
         "content_snippet": "전산유체역학(CFD)의 \"해석 수행(Solving)\" 단계는 전처리(Pre-processing) 과정에서 준비된 기하 형상, 격자, 물리 모델 설정 및 경계 조건 등을 바탕으로, 실제 유체 유동 현상을 지배하는 편미분 방정식(PDE) 시스템을 수치적으로 근사하여 해를 ",
         "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! CFD Solving (해석 수행) 전산유체역학(CFD)의 \"해석 수행(Solving)\" 단계는 전처리(Pre-processing) 과정에서 준비된 기하 형상, 격자, 물리 모델 설정 및 경계 조건 등을 바탕으로, 실제 유체 유동 현상을 지배하는 편미분 방정식(PDE) 시스템을 수치적으로 근사하여 해를 구하는 핵심 절차입니다. 이 단계에서는 선택된 수치 해석 기법을 통해 대규모 대수 방정식 시스템을 구성하고, 반복적인 계산 과정을 거쳐 유동장, 온도장, 압력장, 화학종 농도 분포 등 물리적 해를 도출합니다 [1] , [2] . 정확하고 신뢰성 있는 해석 결과를 얻기 위해서는 문제의 특성에 맞는 적절한 수치 해석 기법과 물리 모델을 선택하고 적용하는 것이 중요합니다. 본 문서는 CFD 해석 수행 단계의 주요 분류 체계인 수치 해석 기법, 난류 모델, 다상 유동 모델, 화학 반응 모델, 열전달 모델, 동적 격자/이동 경계 문제 처리 기법, 검증 및 확인 (V&V), 최신 연구 동향 등을 상세히 설명하고, 각 개념 및 모델들의 원리, 장단점, 적용 분야를 비교 분석하여 전문가 및 학습자에게 심층적인 정보를 제공합니다. 1. 수치 해석 기법 (Numerical Methods) CFD에서 유체 유동을 지배하는 Navier-Stokes 방정식을 포함한 편미분 방정식을 수치적으로 해결하기 위해 다양한 기법이 사용됩니다. 이들은 계산 영역을 이산화(Discretization)하고, 미분 방정식을 대수 방정식 시스템으로 변환하여 컴퓨터가 처리할 수 있도록 합니다. 대표적인 기법으로는 유한 차분법(FDM), 유한 체적법(FVM), 유한 요소법(FEM), 격자 볼츠만 방법(LBM) 등이 있습니다 [1] , [2] , [4] , [5] . 1.1 유한 차분법 (Finite Difference Method, FDM) 이론 및 특징: FDM은 미분 방정식의 각 미분 항을 테일러 급수 전"
+    },
+    {
+        "url": "cfd_statistics.html",
+        "title": "CFD 변수들의 통계적 값 처리 - 유용한 도구 | 생물공학연구실",
+        "breadcrumb": [
+            "홈",
+            "유용한 도구",
+            "CFD 변수들의 통계적 값 처리"
+        ],
+        "keywords": [
+            "CFD",
+            "변수들의",
+            "통계적",
+            "값",
+            "처리",
+            "유용한",
+            "도구",
+            "생물공학연구실"
+        ],
+        "content_snippet": "내용 추가 예정(Coming soon).",
+        "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! CFD 변수들의 통계적 값 처리 내용 추가 예정(Coming soon). 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
     },
     {
         "url": "cfd_terminology.html",
@@ -2630,6 +2672,24 @@
         "full_text": "생물공학연구실 검색 🐹 뭐든 물어봐! 자료실 연구 논문, 발표 자료, 유용한 링크 등을 제공합니다. 출판물 연구실의 주요 논문 및 학술 발표 자료는 추후 업데이트될 예정입니다. 현재 연구 성과 페이지 에서 일부 대표 성과를 확인하실 수 있습니다. 유용한 링크 관련 학회, 연구기관, 소프트웨어 정보 등 유용한 외부 링크 목록은 준비 중입니다. 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
     },
     {
+        "url": "rmse_calculator.html",
+        "title": "RMSE 계산기 - 유용한 도구 | 생물공학연구실",
+        "breadcrumb": [
+            "홈",
+            "유용한 도구",
+            "RMSE 계산기"
+        ],
+        "keywords": [
+            "RMSE",
+            "계산기",
+            "유용한",
+            "도구",
+            "생물공학연구실"
+        ],
+        "content_snippet": "내용 추가 예정(Coming soon).",
+        "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! RMSE 계산기 내용 추가 예정(Coming soon). 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
+    },
+    {
         "url": "software_index.html",
         "title": "소프트웨어 - 전산유체역학 | 생물공학연구실",
         "breadcrumb": [
@@ -2644,5 +2704,20 @@
         ],
         "content_snippet": "본 연구실에서 활용하거나 교육 자료를 제공하는 주요 전산 유체 역학(CFD) 및 관련 소프트웨어 목록입니다. 각 소프트웨어에 대한 상세 정보는 아래 링크를 통해 확인하실 수 있습니다.",
         "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! 소프트웨어 본 연구실에서 활용하거나 교육 자료를 제공하는 주요 전산 유체 역학(CFD) 및 관련 소프트웨어 목록입니다. 각 소프트웨어에 대한 상세 정보는 아래 링크를 통해 확인하실 수 있습니다. M-STAR CFD Lattice Boltzmann 기반의 GPU 가속 CFD 소프트웨어로, 대규모 혼합 및 다상 유동 시스템에 특화되어 있습니다. M-STAR CFD 정보 보기 &raquo; 자세히 알아보기 Ansys Fluent 산업 표준 CFD 소프트웨어로, 복잡한 유동, 열 전달, 화학 반응 등 광범위한 물리 현상 해석에 사용됩니다. Ansys Fluent 정보 보기 &raquo; 자세히 알아보기 OpenFOAM 오픈 소스 CFD 소프트웨어로, 유연성과 확장성이 뛰어나며 다양한 물리 문제 해결에 사용됩니다. OpenFOAM 정보 보기 &raquo; 자세히 알아보기 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
+    },
+    {
+        "url": "useful_tools.html",
+        "title": "유용한 도구 - 생물공학연구실",
+        "breadcrumb": [
+            "홈",
+            "유용한 도구"
+        ],
+        "keywords": [
+            "유용한",
+            "도구",
+            "생물공학연구실"
+        ],
+        "content_snippet": "© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.",
+        "full_text": "생물공학연구실 Bioprocess Engineering Laboratory 검색 🐹 뭐든 물어봐! 유용한 도구 (Useful Tools) CELBIC system angle &amp; RPM setting CFD 변수들의 통계적 값 처리 RMSE 계산기 검색 결과 © 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스. 강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr 연세대학교 미래캠퍼스 생명과학기술학부 본 웹사이트는 교육 및 연구 목적으로 제작되었습니다."
     }
 ]

--- a/useful_tools.html
+++ b/useful_tools.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>유용한 도구 - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="header-container flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="index.html" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden">
+                    </div>
+                </div>
+                <div id="header-helper-btn" class="helper-btn" aria-label="도우미 열기">
+                    <span class="hamster-icon">🐹</span>
+                    <span class="helper-text">뭐든 물어봐!</span>
+                </div>
+            </div>
+        </div>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            <section class="container my-5">
+              <h1 class="display-5 fw-bold">유용한 도구 <span class="text-muted">(Useful Tools)</span></h1>
+
+              <div class="row g-4 mt-4">
+                <!-- CELBIC -->
+                <div class="col-md-4">
+                  <a href="celbic_angle_rpm.html" class="text-decoration-none" role="button" aria-label="CELBIC system angle & RPM setting">
+                    <div class="card h-100 shadow-sm rounded-3">
+                      <div class="card-body text-center">
+                        <i class="bi bi-compass fs-2 mb-2" aria-hidden="true"></i>
+                        <h5 class="card-title mb-0">CELBIC system angle &amp; RPM setting</h5>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+
+                <!-- CFD 통계 -->
+                <div class="col-md-4">
+                  <a href="cfd_statistics.html" class="text-decoration-none" role="button" aria-label="CFD statistical post-processing">
+                    <div class="card h-100 shadow-sm rounded-3">
+                      <div class="card-body text-center">
+                        <i class="bi bi-graph-up fs-2 mb-2" aria-hidden="true"></i>
+                        <h5 class="card-title mb-0">CFD 변수들의 통계적 값 처리</h5>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+
+                <!-- RMSE -->
+                <div class="col-md-4">
+                  <a href="rmse_calculator.html" class="text-decoration-none" role="button" aria-label="RMSE calculator">
+                    <div class="card h-100 shadow-sm rounded-3">
+                      <div class="card-body text-center">
+                        <i class="bi bi-calculator fs-2 mb-2" aria-hidden="true"></i>
+                        <h5 class="card-title mb-0">RMSE 계산기</h5>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </section>
+        </div>
+
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new top-level `Useful Tools` section to the menu structure
- create main `useful_tools.html` page listing tools
- add placeholder pages for each tool
- regenerate `search_index.json`

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_6845bad44ff48333a51a825e64f47d1a