### PR TITLE
Fix i18n diff handling and switch to PR workflow

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
@@ -25,4 +27,10 @@ jobs:
           git config user.name  "i18n-bot"
           git config user.email "bot@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || (git commit -m "i18n: auto-update" && git push)
+          git diff --cached --quiet || git commit -m "i18n: auto-update"
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "i18n: auto-update"
+          title: "♻️ i18n JSON 업데이트"
+          branch: i18n/bot-update
+          labels: i18n, bot

--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -8,8 +8,17 @@ from bs4 import BeautifulSoup
 from google.cloud import translate_v2 as tr
 
 repo = pathlib.Path(__file__).resolve().parents[1]
-changed = subprocess.check_output(['git','diff','--name-only','HEAD~1']).decode().split()
-process_files = [f for f in changed if f.endswith(('.html','.md'))]
+try:
+    diff = subprocess.check_output(
+        ['git', 'diff', '--name-only', 'HEAD~1'], stderr=subprocess.STDOUT
+    ).decode().split()
+except subprocess.CalledProcessError:
+    # 새 브랜치 첫 커밋 등 HEAD~1 없음 → 전체 파일 목록으로 대체
+    diff = subprocess.check_output(
+        ['git', 'ls-files', '*.html', '*.md']
+    ).decode().split()
+
+process_files = [f for f in diff if f.endswith(('.html', '.md'))]
 selectors = ['h1','h2','h3','h4','a.nav-link','button','li>a']
 
 assets_dir = repo / 'assets' / 'i18n'


### PR DESCRIPTION
## Summary
- avoid failure when `HEAD~1` is absent by falling back to `git ls-files`
- set checkout to keep credentials
- create a pull request instead of pushing directly

## Testing
- `python -m py_compile scripts/i18n_full_auto.py`

------
https://chatgpt.com/codex/tasks/task_e_6845edb0558483339a7e812dd3eabef3