### PR TITLE
Add concurrency to update-search-index workflow

### DIFF
--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -7,6 +7,10 @@ on:
       - 'script.js'
       - 'generate_search_index.js'
 
+concurrency:
+  group: search-index
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
- prevent concurrent search index updates by adding a `concurrency` block

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_68462dc3401483338dd7e0c2f84bb3a9