### PR TITLE
Add Google Cloud setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ This repository hosts materials for the BPE-Lab CFD website.
 > **비용 관리:**
 > Cloud Translation API는 월 50 만 자 무료 한도가 있습니다. 초과 시 과금되므로 Google Cloud Billing에서 예산 알림을 설정하세요.
 
+## Setup
+
+1. Generate a service account key JSON in Google Cloud. Navigate to **IAM & Admin → Service Accounts**, create a key in JSON format and download it.
+2. Set the `GCLOUD_SERVICE_KEY` environment variable (or GitHub secret) to the downloaded JSON contents.
+3. Set `GCLOUD_PROJECT_ID` to your Google Cloud project ID.
+4. Optionally configure a budget alert in Google Cloud to avoid unexpected charges.
+
 ## i18n automation
 
 * The `i18n_full.yml` workflow runs on pushes to `main` and ignores branches


### PR DESCRIPTION
## Summary
- explain how to generate a service account key and set `GCLOUD_SERVICE_KEY`
- document `GCLOUD_PROJECT_ID` and budget alerts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684636b643a0833382fa9f1e7677a5f5