### PR TITLE
Expand selectors for i18n automation

### DIFF
--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -26,7 +26,20 @@ if args.skip and not process_files:
     print('No changes detected; skipping i18n update.')
     sys.exit(0)
 
-selectors = ['h1','h2','h3','h4','a.nav-link','button','li>a']
+selectors = [
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'a.nav-link',
+    'button',
+    'li>a',
+    'p',
+    'span',
+    'label',
+    'th',
+    'td'
+]
 
 assets_dir = repo / 'assets' / 'i18n'
 assets_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- update `scripts/i18n_full_auto.py` selectors to capture more HTML elements

## Testing
- `python3 scripts/i18n_full_auto.py` *(fails: No module named 'bs4')*
- `pip install beautifulsoup4` *(fails: could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_684636b47a348333a77975c5b12282f4