### PR TITLE
Handle page titles in i18n script

### DIFF
--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -27,6 +27,7 @@ if args.skip and not process_files:
     sys.exit(0)
 
 selectors = [
+    'title',
     'h1',
     'h2',
     'h3',
@@ -73,7 +74,10 @@ for file in process_files:
                 continue
             key = el.get('data-i18n')
             if not key:
-                key = slug(txt)
+                if el.name == 'title':
+                    key = 'title'
+                else:
+                    key = slug(txt)
                 el['data-i18n'] = key
                 modified = True
             ko[key] = txt


### PR DESCRIPTION
## Summary
- extend i18n selectors to include the `<title>` tag
- assign a constant key of `title` for all `<title>` elements

## Testing
- `python3 scripts/i18n_full_auto.py` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68463878f66c833381f1cd3bd921755d