### PR TITLE
Fix workflow credentials path

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -29,6 +29,7 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          create_credentials_file: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -55,3 +56,6 @@ jobs:
           title: "♻️ i18n JSON 업데이트"
           commit-message: "i18n: auto-update"
           delete-branch: true
+          add-paths: |
+            assets/i18n/**
+            **/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gha-creds-*.json


### PR DESCRIPTION
## Summary
- prevent credential files from being staged
- don't leave GCP creds in repo and limit PR contents in i18n workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684643754be88333b1c1eecc6f560b19