### PR TITLE
Improve i18n text replacement

### DIFF
--- a/script.js
+++ b/script.js
@@ -137,7 +137,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const defaultTexts = {};
 
+    // Store default texts for elements using data-i18n to allow reverting
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+        const key = el.dataset.i18n;
+        if (!(key in defaultTexts)) {
+            defaultTexts[key] = el.hasAttribute('placeholder') ? (el.placeholder || '') : (el.textContent || '');
+        }
+    });
+
     function applyTexts(texts) {
+        // Apply translations for elements marked with data-i18n
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+            const key = el.dataset.i18n;
+            if (key in texts) {
+                if (el.hasAttribute('placeholder')) {
+                    el.placeholder = texts[key];
+                } else {
+                    el.textContent = texts[key];
+                }
+            }
+        });
+
+        // Legacy support: update elements referenced by id keys
         Object.keys(texts).forEach(key => {
             if (key === 'title') {
                 document.title = texts[key];
@@ -148,17 +169,6 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 const element = document.getElementById(key);
                 if (element) element.textContent = texts[key];
-            }
-        });
-
-        document.querySelectorAll('[data-i18n]').forEach(el => {
-            const key = el.dataset.i18n;
-            if (key in texts) {
-                if (el.hasAttribute('placeholder')) {
-                    el.placeholder = texts[key];
-                } else {
-                    el.textContent = texts[key];
-                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- collect default i18n texts from `data-i18n` attributes
- replace texts using `data-i18n` first while keeping ID-based fallback

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_6846458865e483338909e1545168e173