### PR TITLE
Fix i18n workflow credentials

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Auto-tag & translate
         env:
           GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         run: python scripts/i18n_full_auto.py --skip-if-no-diff
 
       - name: Create/Update PR


### PR DESCRIPTION
## Summary
- export `GCLOUD_SERVICE_KEY` for the translation step in the i18n workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464f248a6c8333bad92d22ad1175e2