### PR TITLE
Add force option for i18n script

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -10,6 +10,11 @@ on:
       - '**.html'
       - '!assets/i18n/**'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Translate all files'
+        required: false
+        default: 'false'
 
 concurrency:
   group: i18n-auto
@@ -47,7 +52,8 @@ jobs:
         env:
           GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        run: python scripts/i18n_full_auto.py --skip-if-no-diff
+        run: |
+          python scripts/i18n_full_auto.py --skip-if-no-diff${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true' && ' --force' || '' }}
 
       - name: Create/Update PR
         uses: peter-evans/create-pull-request@v6

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The translation script automatically collects these strings and updates
 
 ```bash
 python scripts/i18n_full_auto.py --skip-if-no-diff
+python scripts/i18n_full_auto.py --force  # when initial translations are missing
 ```
 
 Commit the regenerated JSON files and HTML changes.


### PR DESCRIPTION
## Summary
- add `--force` CLI flag to `i18n_full_auto.py`
- skip diff detection when `--force` is supplied
- note `--force` usage in README
- enable workflow dispatch with optional `force` input
- pass `--force` in workflow when requested

## Testing
- `python -m py_compile scripts/i18n_full_auto.py`

------
https://chatgpt.com/codex/tasks/task_e_68466763abcc83339dcc8c295d09086d