### PR TITLE
Add logging to i18n script

### DIFF
--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -44,6 +44,7 @@ else:
         ).stdout.split()
 
 process_files = [f for f in diff if f.endswith(('.html', '.md'))]
+print(f"Files to process: {len(process_files)}")
 if args.skip and not process_files and not args.force:
     print('No changes detected; skipping i18n update.')
     sys.exit(0)
@@ -132,6 +133,9 @@ for file in process_files:
                 new_keys.add(key)
     if modified:
         path.write_text(str(soup), 'utf-8')
+        print(f"Updated {file}")
+
+print(f"New keys found: {len(new_keys)}")
 
 if new_keys:
     for key in new_keys:


### PR DESCRIPTION
## Summary
- add progress logs to `i18n_full_auto.py`

## Testing
- `python scripts/i18n_full_auto.py --force` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68467e79d1408333b009a3416c0eb164