### PR TITLE
Update workflow add-paths and README

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -69,5 +69,5 @@ jobs:
           commit-message: "i18n: auto-update"
           delete-branch: true
           add-paths: |
-            'assets/i18n/**'
-            ':(glob)**/*.html'
+            assets/i18n/**
+            :'(glob)**/*.html'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository hosts materials for the BPE-Lab CFD website.
   translation files are added.
 * When manually dispatching the workflow, set the `force` input to the exact
   string `true` to translate all files.
+* 처음 번역을 수행할 때는 GitHub Actions에서 `force: true`를 입력하고 워크플로를 실행한다.
 
 
 ## Supported languages


### PR DESCRIPTION
## Summary
- include HTML globbing with git pathspec for `create-pull-request`
- mention running workflow with `force: true` on first translation

## Testing
- `pytest -q`
- `python scripts/i18n_full_auto.py --force` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6846888b0fa08333802614a4465b1afa