### PR TITLE
Fix i18n pathspec quoting

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -70,4 +70,4 @@ jobs:
           delete-branch: true
           add-paths: |
             assets/i18n/**
-            :'(glob)**/*.html'
+            ':(glob)**/*.html'


### PR DESCRIPTION
## Summary
- fix quoting for glob pathspec in i18n workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846910235bc833381c420cd5651cfd5