### PR TITLE
Fix translation client project setup

### DIFF
--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -91,7 +91,8 @@ if not project_id:
     print('Error: GCLOUD_PROJECT_ID environment variable not set.', file=sys.stderr)
     sys.exit(1)
 
-client = tr.Client(credentials=credentials, project=project_id) if credentials else tr.Client(project=project_id)
+os.environ.setdefault('GOOGLE_CLOUD_PROJECT', project_id)
+client = tr.Client(credentials=credentials)
 try:
     client.get_languages()
 except Exception as exc:


### PR DESCRIPTION
## Summary
- set `GOOGLE_CLOUD_PROJECT` from `GCLOUD_PROJECT_ID`
- drop unsupported `project` argument when creating the translation client

## Testing
- `python -m py_compile scripts/i18n_full_auto.py`

------
https://chatgpt.com/codex/tasks/task_e_684690fe41d48333b33fef03d55212a8