### PR TITLE
Update i18n workflow paths

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -70,4 +70,4 @@ jobs:
           delete-branch: true
           add-paths: |
             assets/i18n/**
-            ':(glob)**/*.html'
+            :(glob)**/*.html


### PR DESCRIPTION
## Summary
- fix pattern in i18n workflow `add-paths`

## Testing
- `curl -I https://api.github.com` *(fails: 403 Forbidden)*
- `curl -X POST -H "Authorization: token FAKE" https://api.github.com/repos/OWNER/REPO/actions/workflows/i18n_full.yml/dispatches -d '{"ref":"main","inputs":{"force":"true"}}'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68469f85a1b88333a26688825ff4515a