### PR TITLE
Fix quoting for create-pull-request add-paths

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -70,4 +70,4 @@ jobs:
           delete-branch: true
           add-paths: |
             assets/i18n/**
-            :(glob)**/*.html
+            ':(glob)**/*.html'


### PR DESCRIPTION
## Summary
- quote HTML glob path passed to create-pull-request

## Testing
- `pip install beautifulsoup4==4.12.* google-cloud-translate==3.*` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846a3c55ff4833391a17c4426e3c8e4