### PR TITLE
Fix i18n workflow glob

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -73,4 +73,4 @@ jobs:
           delete-branch: true
           add-paths: |
             assets/i18n/**
-            ':(glob)**/*.html'
+            :(glob)**/*.html


### PR DESCRIPTION
## Summary
- correct path globbing in `i18n_full.yml`

## Testing
- `curl -X POST https://api.github.com` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6846a76bc57883338f997e9b452d7a05