### PR TITLE
Update i18n workflow docs and script

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -55,8 +55,11 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         run: |
           cmd="python scripts/i18n_full_auto.py --skip-if-no-diff"
-          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+          force_input="${{ github.event.inputs.force }}"
+          if [ "$force_input" = "true" ]; then
             cmd="$cmd --force"
+          else
+            echo "Warning: force input '$force_input' is not 'true'; running without --force"
           fi
           echo "Running: $cmd"
           $cmd

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository hosts materials for the BPE-Lab CFD website.
 * When manually dispatching the workflow, set the `force` input to the exact
   string `true` to translate all files.
 * 처음 번역을 수행할 때는 GitHub Actions에서 `force: true`를 입력하고 워크플로를 실행한다.
+* 처음 번역할 때는 GitHub Actions에서 **Run workflow → force 입력란에 반드시 `true`를 입력**해야 모든 페이지가 번역됩니다.
 
 
 ## Supported languages


### PR DESCRIPTION
## Summary
- emphasize forcing full translation on first run
- warn when i18n workflow input is not exactly `true`

## Testing
- `python -m py_compile scripts/i18n_full_auto.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ae589f2483338aeed0e26224c1e0