### PR TITLE
Improve translation error handling

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -62,7 +62,15 @@ jobs:
             echo "Warning: force input '$force_input' is not 'true'; running without --force"
           fi
           echo "Running: $cmd"
+          set +e
           $cmd
+          status=$?
+          set -e
+          echo "Translation script exited with $status"
+          if [ $status -ne 0 ]; then
+            echo "::error::Translation failed"
+            exit $status
+          fi
 
       - name: Check git status
         run: git status --short

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository hosts materials for the BPE-Lab CFD website.
   translation files are added.
 * When manually dispatching the workflow, set the `force` input to the exact
   string `true` to translate all files.
+* The script fails fast when Google Cloud credentials are invalid so missing
+  translations are easy to spot.
 * 처음 번역을 수행할 때는 GitHub Actions에서 `force: true`를 입력하고 워크플로를 실행한다.
 * 처음 번역할 때는 GitHub Actions에서 **Run workflow → force 입력란에 반드시 `true`를 입력**해야 모든 페이지가 번역됩니다.
 

--- a/archive/i18n_full_auto.py
+++ b/archive/i18n_full_auto.py
@@ -8,6 +8,7 @@ import sys
 from bs4 import BeautifulSoup
 from google.cloud import translate_v2 as tr
 from google.oauth2 import service_account
+from google.auth.exceptions import GoogleAuthError
 
 repo = pathlib.Path(__file__).resolve().parents[1]
 result = subprocess.run(
@@ -58,6 +59,9 @@ if not project_id:
 client = tr.Client(credentials=credentials, project=project_id) if credentials else tr.Client(project=project_id)
 try:
     client.get_languages()
+except GoogleAuthError as exc:
+    print(f'Invalid Google Cloud credentials: {exc}', file=sys.stderr)
+    sys.exit(1)
 except Exception as exc:
     print(f'Error verifying Cloud Translation API access: {exc}', file=sys.stderr)
     sys.exit(1)
@@ -75,6 +79,9 @@ def translate_or_exit(text, target_language):
             target_language=target_language,
             source_language='ko'
         )['translatedText']
+    except GoogleAuthError as exc:
+        print(f'Invalid Google Cloud credentials: {exc}', file=sys.stderr)
+        sys.exit(1)
     except Exception as exc:
         print(f'Error translating to {target_language}: {exc}', file=sys.stderr)
         sys.exit(1)

--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -2,6 +2,7 @@ import subprocess, pathlib, json, re, hashlib, os, sys, argparse
 from bs4 import BeautifulSoup
 from google.cloud import translate_v2 as tr
 from google.oauth2 import service_account
+from google.auth.exceptions import GoogleAuthError
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--skip-if-no-diff', action='store_true', dest='skip')
@@ -103,6 +104,9 @@ os.environ.setdefault('GOOGLE_CLOUD_PROJECT', project_id)
 client = tr.Client(credentials=credentials)
 try:
     client.get_languages()
+except GoogleAuthError as exc:
+    print(f'Invalid Google Cloud credentials: {exc}', file=sys.stderr)
+    sys.exit(1)
 except Exception as exc:
     print(f'Error verifying Cloud Translation API access: {exc}', file=sys.stderr)
     sys.exit(1)
@@ -122,6 +126,9 @@ def translate_or_exit(text, target_language, key):
         )['translatedText']
         print(f"Translated {key} -> {target_language}")
         return result
+    except GoogleAuthError as exc:
+        print(f'Invalid Google Cloud credentials: {exc}', file=sys.stderr)
+        sys.exit(1)
     except Exception as exc:
         msg = f"Error translating key '{key}' to {target_language}: {type(exc).__name__}: {exc}"
         print(msg, file=sys.stderr)


### PR DESCRIPTION
## Summary
- catch authentication errors during `client.translate()` calls
- stop the workflow if the translation script exits non-zero
- document the credential failure behaviour

## Testing
- `python -m py_compile scripts/i18n_full_auto.py archive/i18n_full_auto.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b187693c8333a34992b9aad08c3f