### PR TITLE
Add div selector for i18n

### DIFF
--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -76,7 +76,8 @@ selectors = [
     'th',
     'td',
     'input[placeholder]',
-    'textarea[placeholder]'
+    'textarea[placeholder]',
+    'div'
 ]
 
 credentials = None


### PR DESCRIPTION
## Summary
- capture text inside `<div>` tags by including `'div'` in selectors in `i18n_full_auto.py`

## Testing
- `python -m py_compile scripts/i18n_full_auto.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b1869ea883338c0d7e68fd4ba23d