### PR TITLE
Update selectors for image alt text support

### DIFF
--- a/scripts/i18n_full_auto.py
+++ b/scripts/i18n_full_auto.py
@@ -78,6 +78,7 @@ selectors = [
     'td',
     'input[placeholder]',
     'textarea[placeholder]',
+    'img[alt]',
     'div'
 ]
 


### PR DESCRIPTION
## Summary
- expand selector list in `i18n_full_auto.py` to include images with `alt` attributes

## Testing
- `python3 scripts/i18n_full_auto.py --skip-if-no-diff` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6846b575d224833395df77c1fb5e578f