### PR TITLE
Fix i18n workflow pathspec

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -85,4 +85,4 @@ jobs:
           delete-branch: true
           add-paths: |
             assets/i18n/**
-            '**/*.html'
+            ':(glob)**/*.html'


### PR DESCRIPTION
## Summary
- update i18n workflow to use proper glob pathspec for HTML files

## Testing
- `python3 scripts/i18n_full_auto.py --force` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6846efb3124083339829a5392576d511