### PR TITLE
Fix i18n workflow pathspec

### DIFF
--- a/.github/workflows/i18n_full.yml
+++ b/.github/workflows/i18n_full.yml
@@ -85,4 +85,4 @@ jobs:
           delete-branch: true
           add-paths: |
             assets/i18n/**
-            ':(glob)**/*.html'
+            :(glob)**/*.html


### PR DESCRIPTION
## Summary
- fix pathspec quoting in `i18n_full.yml`

## Testing
- `gh workflow run "i18n full-auto" -F force=true` *(fails: gh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846f1cd146883338ce3df15af06e9cf