### PR TITLE
Add google translate widget

### DIFF
--- a/script.js
+++ b/script.js
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (fixedNavContainer && mainNav) {
-        const headerFlex = fixedNavContainer.querySelector('.flex-col');
+        const headerFlex = fixedNavContainer.querySelector('.flex-col') || fixedNavContainer.querySelector('.header-container');
         if (headerFlex) {
             const menuToggle = document.createElement('button');
             menuToggle.className = 'menu-toggle sm:hidden p-2 text-gray-700';
@@ -95,8 +95,27 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (lucide) lucide.createIcons();
             });
 
+            const translateDiv = document.createElement('div');
+            translateDiv.id = 'google_translate_element';
+            const helperBtnHeader = document.getElementById('header-helper-btn');
+            headerFlex.insertBefore(translateDiv, helperBtnHeader || null);
+
             if (lucide) lucide.createIcons();
         }
+        function initGoogleTranslate() {
+            window.googleTranslateElementInit = function() {
+                new google.translate.TranslateElement({
+                    pageLanguage: 'ko',
+                    includedLanguages: 'en,zh-CN,ja,hi,de,fr',
+                    layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+                }, 'google_translate_element');
+            };
+            const s = document.createElement('script');
+            s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+            s.defer = true;
+            document.head.appendChild(s);
+        }
+        initGoogleTranslate();
     }
     
     function adjustBodyPadding() {

--- a/style.css
+++ b/style.css
@@ -904,3 +904,19 @@ td {
   .calc-form   {grid-template-columns:1fr;grid-auto-rows:auto;}
 }
 /* === celbic-angle-rpm|UI_REFINEMENT_END === */
+
+/* === google-translate-widget|START === */
+#google_translate_element {
+  display: inline-block;
+  margin-left: 1rem;
+  font-size: 0.85rem;
+  vertical-align: middle;
+}
+
+@media (max-width: 768px) {
+  #google_translate_element {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+}
+/* === google-translate-widget|END === */


### PR DESCRIPTION
## Summary
- integrate Google translate widget for 7 languages
- style widget for desktop and mobile

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6849b5330ac48333ab6e0e1bc1f8b50f