### PR TITLE
Improve software card UI on software_index

### DIFF
--- a/software_index.html
+++ b/software_index.html
@@ -49,24 +49,24 @@
                 <p>본 연구실에서 활용하거나 교육 자료를 제공하는 주요 전산 유체 역학(CFD) 및 관련 소프트웨어 목록입니다. 각 소프트웨어에 대한 상세 정보는 아래 링크를 통해 확인하실 수 있습니다.</p>
                 
                 <div class="mt-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 not-prose">
-                     <div class="bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-purple-500">
-                        <h2 class="text-2xl font-semibold mb-3 text-purple-700">M-STAR CFD</h2>
+                    <div class="software-card bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-purple-500">
+                        <h2 class="software-card-title text-2xl font-semibold mb-3 text-purple-700">M-STAR CFD</h2>
                         <p class="software-description text-gray-600 mb-4 flex-grow">Lattice Boltzmann 기반의 GPU 가속 CFD 소프트웨어로, 대규모 혼합 및 다상 유동 시스템에 특화되어 있습니다.</p>
                         <a href="mstar_cfd_main.html" class="software-index-btn bg-[#0072CE] text-white px-4 py-2 rounded hover:bg-[#004A99] transition-colors mt-auto font-medium">
                             M-STAR CFD 정보 보기 &raquo;
                             <span class="learn-more-text block mt-1 text-white/80">자세히 알아보기</span>
                         </a>
                     </div>
-                    <div class="bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-sky-500">
-                        <h2 class="text-2xl font-semibold mb-3 text-sky-700">Ansys Fluent</h2>
+                    <div class="software-card bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-sky-500">
+                        <h2 class="software-card-title text-2xl font-semibold mb-3 text-sky-700">Ansys Fluent</h2>
                         <p class="software-description text-gray-600 mb-4 flex-grow">산업 표준 CFD 소프트웨어로, 복잡한 유동, 열 전달, 화학 반응 등 광범위한 물리 현상 해석에 사용됩니다.</p>
                         <a href="ansys_fluent_main.html" class="software-index-btn bg-[#0072CE] text-white px-4 py-2 rounded hover:bg-[#004A99] transition-colors mt-auto font-medium">
                             Ansys Fluent 정보 보기 &raquo;
                             <span class="learn-more-text block mt-1 text-white/80">자세히 알아보기</span>
                         </a>
                     </div>
-                    <div class="bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-green-500">
-                        <h2 class="text-2xl font-semibold mb-3 text-green-700">OpenFOAM</h2>
+                    <div class="software-card bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-green-500">
+                        <h2 class="software-card-title text-2xl font-semibold mb-3 text-green-700">OpenFOAM</h2>
                         <p class="software-description text-gray-600 mb-4 flex-grow">오픈 소스 CFD 소프트웨어로, 유연성과 확장성이 뛰어나며 다양한 물리 문제 해결에 사용됩니다.</p>
                         <a href="openfoam_main.html" class="software-index-btn bg-[#0072CE] text-white px-4 py-2 rounded hover:bg-[#004A99] transition-colors mt-auto font-medium">
                             OpenFOAM 정보 보기 &raquo;

--- a/style.css
+++ b/style.css
@@ -792,6 +792,22 @@ h1.main-title {
   text-align: center;
 }
 
+/* === software-card|UI_TWEAK_START === */
+.software-card .software-card-title {
+  font-size: calc(1.5rem + 2pt);
+  text-align: center;
+}
+
+.software-card .software-description {
+  font-size: calc(1.2rem - 1pt);
+}
+
+.software-card .software-index-btn {
+  padding-top: calc(0.5rem * 0.67);
+  padding-bottom: calc(0.5rem * 0.67);
+}
+/* === software-card|UI_TWEAK_END === */
+
 /* Larger text for the "자세히 알아보기" span inside software buttons */
 .learn-more-text {
   font-size: 1.2em;
@@ -811,9 +827,11 @@ h1.main-title {
   }
   .software-index-btn {
     font-size: 1rem;
+    padding-top: calc(0.5rem * 0.67);
+    padding-bottom: calc(0.5rem * 0.67);
   }
   .software-description {
-    font-size: 1rem;
+    font-size: calc(1rem - 1pt);
   }
   .learn-more-text {
     font-size: 1.1em;


### PR DESCRIPTION
## Summary
- add `software-card` container to each software card
- enlarge card title text, center align, tweak description font
- shrink vertical padding on card buttons for consistent height

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_6849d9fc458883338206491133647689