### PR TITLE
Fix button text vertical alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -803,8 +803,12 @@ h1.main-title {
 }
 
 .software-card .software-index-btn {
-  padding-top: calc(0.5rem * 0.67);
-  padding-bottom: calc(0.5rem * 0.67);
+  padding-top: calc(0.5rem * 0.67 - 2px);
+  padding-bottom: calc(0.5rem * 0.67 - 2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: normal;
 }
 /* === software-card|UI_TWEAK_END === */
 


### PR DESCRIPTION
## Summary
- center learn-more buttons by adjusting padding
- ensure text is flex-centered within software card buttons

## Testing
- `jekyll serve` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dcaab7888333abcefccbb1d83351