### PR TITLE
Fix upload input and support TXT files

### DIFF
--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -58,7 +58,7 @@
                     <p><i class="fa fa-cloud-upload-alt"></i><br>파일을 드래그하거나<br><b>[파일 첨부]</b>를 클릭하세요</p>
                     <input id="file-input" hidden
                            type="file"
-                           accept=".csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel">
+                           accept=".csv,.txt,text/plain,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel">
                     <button id="file-btn" class="btn secondary">파일 첨부</button>
                 </div>
                 <div id="file-preview" class="file-preview d-none" aria-live="polite">


### PR DESCRIPTION
## Summary
- broaden file input to allow txt
- handle drag/drop events correctly and support csv/txt/excel files
- reset file input only when removing file

## Testing
- `node --check assets/js/cfd-statistics.js`

------
https://chatgpt.com/codex/tasks/task_e_6849deabcd788333aac4bf03a4c08a47