### PR TITLE
Fix button text vertical alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -808,6 +808,8 @@ h1.main-title {
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Visually nudge button text upward for better centering */
+  transform: translateY(-1px);
   line-height: normal;
 }
 /* === software-card|UI_TWEAK_END === */


### PR DESCRIPTION
## Summary
- adjust software index button style so "Learn more" text is visually centered

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849df82ff648333819ff7d2b63e5f28