### PR TITLE
Fix button vertical centering for software cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -941,3 +941,14 @@ td {
 .btn.icon{padding:.25rem .5rem}
 .note-table-wrapper{width:100%;overflow-x:auto}
 /* === cfd-statistics|STYLE_END === */
+
+/* === software-card|BTN_V_CENTER_OVERRIDE === */
+.software-card .btn,
+.software-card .btn-primary {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  line-height: 1 !important;
+  padding: 0.50rem 1.50rem !important;
+}
+/* === END === */


### PR DESCRIPTION
## Summary
- override Bootstrap `.btn` styles for software card buttons so text is vertically centered

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6849e5dddce08333b133bbbe4fe63a54