### PR TITLE
Refactor CFD statistics tool to use site template

### DIFF
--- a/_layouts/tool.html
+++ b/_layouts/tool.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title }} - 생물공학연구실</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link href="{{ '/style.css' | relative_url }}" rel="stylesheet">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+
+    <div id="fixed-top-nav-container" class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="header-container flex flex-col sm:flex-row justify-between items-center py-3">
+                <h1 class="text-slate-800 mb-2 sm:mb-0">
+                    <a href="{{ 'index.html' | relative_url }}" class="block no-underline hover:no-underline">
+                        <span class="block text-2xl lg:text-3xl font-bold text-slate-800">생물공학연구실</span>
+                        <span class="block text-sm lg:text-base font-normal text-gray-500 mt-1">Bioprocess Engineering Laboratory</span>
+                    </a>
+                </h1>
+        <nav id="mainNav" class="bg-slate-700 text-white border-t border-b border-slate-600">
+            <ul class="container mx-auto px-0 flex justify-center">
+            </ul>
+        </nav>
+                <div class="search-container relative flex items-center flex-shrink-0 w-full sm:w-auto sm:ml-4">
+                    <input type="text" id="searchInput" placeholder="검색..." class="px-3 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-yellow-400 text-sm w-full sm:w-48 md:w-64">
+                    <button id="searchButton" class="px-4 py-2 bg-[#0072CE] text-white rounded-r-md hover:bg-[#004A99] text-sm border border-[#0072CE]">검색</button>
+                    <div id="suggestionsDropdown" class="absolute top-full mt-1 w-full rounded-md bg-white shadow-lg z-[60] border border-gray-200 hidden"></div>
+                </div>
+                <div id="header-helper-btn" class="helper-btn" aria-label="도우미 열기">
+                    <span class="hamster-icon">🐹</span>
+                    <span class="helper-text">뭐든 물어봐!</span>
+                </div>
+            </div>
+        </div>
+        <nav id="breadcrumbNav" aria-label="breadcrumb" class="bg-gray-100 border-b border-gray-200">
+            <div class="container mx-auto px-4 py-2 text-sm text-gray-500">
+            </div>
+        </nav>
+    </div>
+
+    <main class="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white p-6 sm:p-8 rounded-lg shadow-lg">
+            {{ content }}
+        </div>
+
+        <div id="searchResultsContainer" class="mt-8 p-6 bg-white rounded-lg shadow-lg hidden">
+            <h2 class="text-2xl font-semibold mb-4 text-slate-700">검색 결과</h2>
+            <div id="searchResultsList" class="space-y-4"></div>
+        </div>
+    </main>
+
+    <footer class="text-center py-8 mt-12 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto px-6 text-sm text-gray-600">
+            <p>© 2025 생물공학연구실 (Bioprocess Engineering Laboratory), 연세대학교 미래캠퍼스.</p>
+            <p class="mt-1">강원특별자치도 원주시 흥업면 연세대길 1, 미래관 306호 | ☎ 033-760-2279 | ✉ jongkwang.hong@yonsei.ac.kr</p>
+            <p class="mt-1">
+                <a href="https://www.yonsei.ac.kr/sc/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline">연세대학교</a>
+                <a href="https://mirae.yonsei.ac.kr/wj/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">미래캠퍼스</a>
+                <a href="https://bst.yonsei.ac.kr/ymbst21/index.do" target="_blank" rel="noopener noreferrer" class="text-[#0072CE] hover:text-[#004A99] hover:underline ml-1">생명과학기술학부</a>
+            </p>
+            <p class="text-xs text-gray-500 mt-1">본 웹사이트는 교육 및 연구 목적으로 제작되었습니다.</p>
+        </div>
+    </footer>
+
+    <script src="{{ '/script.js' | relative_url }}" type="module"></script>
+</body>
+</html>

--- a/assets/css/cfd-stat.css
+++ b/assets/css/cfd-stat.css
@@ -2,3 +2,7 @@
 .uploader.dragover{border-color:#2196f3;background:#f1f9ff;}
 .filename{margin-top:8px;font-weight:600;}
 #result-box{margin-top:20px;font-family:monospace;}
+#drop{border:2px dashed #888;border-radius:8px;padding:60px 20px;text-align:center;cursor:pointer;}
+#drop.drag{border-color:#2196f3;background:#f1f9ff;}
+table{margin:24px auto;border-collapse:collapse;}
+th,td{border:1px solid #ccc;padding:6px 12px;}

--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -1,0 +1,61 @@
+const drop = document.getElementById('drop');
+const file = document.getElementById('file');
+const out  = document.getElementById('out');
+
+['dragenter','dragover','dragleave','drop'].forEach(ev=>{
+  drop.addEventListener(ev,e=>{e.preventDefault();e.stopPropagation();});
+});
+drop.addEventListener('dragover',()=>drop.classList.add('drag'));
+drop.addEventListener('dragleave',()=>drop.classList.remove('drag'));
+drop.addEventListener('drop',e=>{
+  drop.classList.remove('drag');
+  handle(e.dataTransfer.files[0]);
+});
+drop.addEventListener('click',()=>file.click());
+file.addEventListener('change',e=>handle(e.target.files[0]));
+
+function handle(f){
+  if(!f)return;
+  drop.innerHTML = `📄 <span class="filename">${f.name}</span>`;
+  const ext = f.name.split('.').pop().toLowerCase();
+  (ext==='csv'||ext==='txt') ? readCSV(f) : readXLSX(f);
+}
+
+function readCSV(f){
+  Papa.parse(f,{
+    complete:({data})=>show(avg(data)),
+    dynamicTyping:true
+  });
+}
+
+function readXLSX(f){
+  f.arrayBuffer().then(b=>{
+    const wb=XLSX.read(b,{type:'array'});
+    const ws=wb.Sheets[wb.SheetNames[0]];
+    const data=XLSX.utils.sheet_to_json(ws,{header:1});
+    show(avg(data));
+  });
+}
+
+function avg(rows){
+  const sums=[], cnts=[];
+  rows.forEach(r=>{
+    r.forEach((v,i)=>{
+      if(typeof v==='number'&&!isNaN(v)){
+        sums[i]=(sums[i]||0)+v;
+        cnts[i]=(cnts[i]||0)+1;
+      }
+    });
+  });
+  return sums.map((s,i)=>cnts[i]? (s/cnts[i]).toFixed(2) : '');
+}
+
+function show(a){
+  if(!a.length){out.textContent='숫자 데이터가 없습니다.';return;}
+  const head=a.map((_,i)=>String.fromCharCode(65+i));
+  const tbl=`<table>
+      <tr>${head.map(h=>`<th>${h}</th>`).join('')}</tr>
+      <tr>${a.map(v=>`<td>${v}</td>`).join('')}</tr>
+    </table>`;
+  out.innerHTML=tbl;
+}

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -1,86 +1,17 @@
-<!DOCTYPE html>
-<html lang="ko">
-<head>
-  <meta charset="UTF-8">
-  <title>데이터 평균 계산기</title>
-  <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
-  <style>
-    body{font-family:Arial,Helvetica,sans-serif;margin:40px;text-align:center;}
-    #drop{border:2px dashed #888;border-radius:8px;padding:60px 20px;cursor:pointer;}
-    #drop.drag{border-color:#2196f3;background:#f1f9ff;}
-    .filename{margin-top:10px;font-weight:600;}
-    table{margin:24px auto;border-collapse:collapse;}
-    th,td{border:1px solid #ccc;padding:6px 12px;}
-  </style>
-</head>
-<body>
-  <h1>데이터 평균 계산기</h1>
-  <div id="drop">여기로 파일을 끌어오거나 클릭하여 첨부</div>
-  <input id="file" type="file" accept=".xlsx,.xls,.csv,.txt" hidden>
-  <div id="out"></div>
+---
+title: "CFD Statistics"
+layout: tool
+parent: "유용한 도구"
+nav_order: 2
+---
 
-  <script>
-    const drop = document.getElementById('drop');
-    const file = document.getElementById('file');
-    const out  = document.getElementById('out');
+<link rel="stylesheet" href="{{ '/assets/css/cfd-stat.css' | relative_url }}">
 
-    ['dragenter','dragover','dragleave','drop'].forEach(ev=>{
-      drop.addEventListener(ev,e=>{e.preventDefault();e.stopPropagation();});
-    });
-    drop.addEventListener('dragover',()=>drop.classList.add('drag'));
-    drop.addEventListener('dragleave',()=>drop.classList.remove('drag'));
-    drop.addEventListener('drop',e=>{
-      drop.classList.remove('drag');
-      handle(e.dataTransfer.files[0]);
-    });
-    drop.addEventListener('click',()=>file.click());
-    file.addEventListener('change',e=>handle(e.target.files[0]));
+<h1>데이터 평균 계산기</h1>
+<div id="drop">여기로 파일을 끌어오거나 클릭하여 첨부</div>
+<input id="file" type="file" accept=".xlsx,.xls,.csv,.txt" hidden>
+<div id="out"></div>
 
-    function handle(f){
-      if(!f)return;
-      drop.innerHTML = `📄 <span class="filename">${f.name}</span>`;
-      const ext = f.name.split('.').pop().toLowerCase();
-      (ext==='csv'||ext==='txt') ? readCSV(f) : readXLSX(f);
-    }
-
-    function readCSV(f){
-      Papa.parse(f,{
-        complete:({data})=>show(avg(data)),
-        dynamicTyping:true
-      });
-    }
-    function readXLSX(f){
-      f.arrayBuffer().then(b=>{
-        const wb=XLSX.read(b,{type:'array'});
-        const ws=wb.Sheets[wb.SheetNames[0]];
-        const data=XLSX.utils.sheet_to_json(ws,{header:1});
-        show(avg(data));
-      });
-    }
-
-    function avg(rows){
-      const sums=[], cnts=[];
-      rows.forEach(r=>{
-        r.forEach((v,i)=>{
-          if(typeof v==='number'&&!isNaN(v)){
-            sums[i]=(sums[i]||0)+v;
-            cnts[i]=(cnts[i]||0)+1;
-          }
-        });
-      });
-      return sums.map((s,i)=>cnts[i]? (s/cnts[i]).toFixed(2) : '');
-    }
-
-    function show(a){
-      if(!a.length){out.textContent='숫자 데이터가 없습니다.';return;}
-      const head=a.map((_,i)=>String.fromCharCode(65+i));
-      const tbl=`<table>
-          <tr>${head.map(h=>`<th>${h}</th>`).join('')}</tr>
-          <tr>${a.map(v=>`<td>${v}</td>`).join('')}</tr>
-        </table>`;
-      out.innerHTML=tbl;
-    }
-  </script>
-</body>
-</html>
+<script src="{{ '/assets/js/libs/xlsx.full.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/libs/papaparse.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/cfd-stat-simple.js' | relative_url }}"></script>

--- a/search_index.json
+++ b/search_index.json
@@ -1110,18 +1110,16 @@
     },
     {
         "url": "cfd_statistics.html",
-        "title": "데이터 평균 계산기",
+        "title": "cfd_statistics.html",
         "breadcrumb": [
             "홈",
-            "데이터 평균 계산기"
+            "cfd_statistics.html"
         ],
         "keywords": [
-            "데이터",
-            "평균",
-            "계산기"
+            "cfd_statisticshtml"
         ],
         "content_snippet": "",
-        "full_text": "데이터 평균 계산기 여기로 파일을 끌어오거나 클릭하여 첨부 const drop = document.getElementById('drop'); const file = document.getElementById('file'); const out = document.getElementById('out'); ['dragenter','dragover','dragleave','drop'].forEach(ev=>{ drop.addEventListener(ev,e=>{e.preventDefault();e.stopPropagation();}); }); drop.addEventListener('dragover',()=>drop.classList.add('drag')); drop.addEventListener('dragleave',()=>drop.classList.remove('drag')); drop.addEventListener('drop',e=>{ drop.classList.remove('drag'); handle(e.dataTransfer.files[0]); }); drop.addEventListener('click',()=>file.click()); file.addEventListener('change',e=>handle(e.target.files[0])); function handle(f){ if(!f)return; drop.innerHTML = `📄 ${f.name} `; const ext = f.name.split('.').pop().toLowerCase(); (ext==='csv'||ext==='txt') ? readCSV(f) : readXLSX(f); } function readCSV(f){ Papa.parse(f,{ complete:({data})=>show(avg(data)), dynamicTyping:true }); } function readXLSX(f){ f.arrayBuffer().then(b=>{ const wb=XLSX.read(b,{type:"
+        "full_text": ""
     },
     {
         "url": "cfd_terminology.html",


### PR DESCRIPTION
## Summary
- create Jekyll-style layout `tool.html`
- move inline CFD stats script to `cfd-stat-simple.js`
- hook new layout and assets from `cfd_statistics.html`
- extend `cfd-stat.css` for drop zone styles

## Testing
- `node generate_search_index.js`

------
https://chatgpt.com/codex/tasks/task_e_684a59ca11c083339999ed779022d5f6