### PR TITLE
Add library checks to cfd-stat-simple.js

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -22,7 +22,19 @@ function handleFile(f){
   // 파일명 표시
   drop.innerHTML = `📄 <span class="filename">${f.name}</span>`;
   const ext = f.name.split('.').pop().toLowerCase();
-  (ext === 'csv' || ext === 'txt') ? parseCSV(f) : parseXLSX(f);
+  if(ext === 'csv' || ext === 'txt'){
+    if(typeof Papa === 'undefined'){
+      console.error('Missing Papa Parse library');
+      return;
+    }
+    parseCSV(f);
+  }else{
+    if(typeof XLSX === 'undefined'){
+      console.error('Missing XLSX library');
+      return;
+    }
+    parseXLSX(f);
+  }
 }
 
 /* ---------- CSV / TXT ---------- */


### PR DESCRIPTION
## Summary
- verify that `Papa` or `XLSX` libraries exist before parsing files
- log an error and exit early from `handleFile` when libraries are missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a5ef9fa988333bd091447c82c8070