### PR TITLE
Fix file drop display to avoid innerHTML

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -20,7 +20,11 @@ file.addEventListener('change',e=>handleFile(e.target.files[0]));
 function handleFile(f){
   if(!f) return;
   // 파일명 표시
-  drop.innerHTML = `📄 <span class="filename">${f.name}</span>`;
+  drop.textContent = '📄 ';
+  const span = document.createElement('span');
+  span.className = 'filename';
+  span.textContent = f.name;
+  drop.appendChild(span);
   const ext = f.name.split('.').pop().toLowerCase();
   if(ext === 'csv' || ext === 'txt'){
     if(typeof Papa === 'undefined'){

--- a/assets/js/cfd-stat.js
+++ b/assets/js/cfd-stat.js
@@ -18,7 +18,11 @@ input.addEventListener('change',e=>handleFile(e.target.files[0]));
 
 function handleFile(file){
   if(!file)return;
-  drop.innerHTML = `<span class="filename">📄 ${file.name}</span>`;
+  drop.textContent = '📄 ';
+  const span = document.createElement('span');
+  span.className = 'filename';
+  span.textContent = file.name;
+  drop.appendChild(span);
   const ext = file.name.split('.').pop().toLowerCase();
   if(['csv','txt'].includes(ext)) parseCSV(file);
   else parseXLSX(file);


### PR DESCRIPTION
## Summary
- use `textContent` and append DOM elements when showing uploaded file name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a6161e20083339b55d614a810fb57