### PR TITLE
Add server-based password validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,17 @@
 
 This repository hosts materials for the BPE-Lab CFD website.
 
+## Local Development
+
+The site can be served using the provided `server.js`. The server reads the
+protected resource password from the `ACCESS_PASSWORD` environment variable and
+exposes an endpoint used by the frontend for validation.
+
+```bash
+ACCESS_PASSWORD=bioprocess2025 node server.js
+```
+
+The site will be available at `http://localhost:3000` by default.
+
 
 

--- a/script.js
+++ b/script.js
@@ -128,13 +128,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function checkPassword() {
         const input = document.getElementById('passwordInput').value;
-        const correctPassword = 'bioprocess2025';
-        if (input === correctPassword) {
-            sessionStorage.setItem('labResourcesAccess', 'true');
-            window.location.href = 'lab_resources.html';
-        } else {
-            alert(jsI18n.wrong_password_alert);
-        }
+        fetch('/validate-password', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ password: input })
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.valid) {
+                sessionStorage.setItem('labResourcesAccess', 'true');
+                window.location.href = 'lab_resources.html';
+            } else {
+                alert(jsI18n.wrong_password_alert);
+            }
+        })
+        .catch(() => alert(jsI18n.wrong_password_alert));
     }
 
     function closeOverlay() {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PASSWORD = process.env.ACCESS_PASSWORD;
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+app.post('/validate-password', (req, res) => {
+  const { password } = req.body || {};
+  if (PASSWORD && password === PASSWORD) {
+    res.json({ valid: true });
+  } else {
+    res.json({ valid: false });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a minimal Express server that validates the password using an env var
- update `checkPassword()` to request validation from the server
- document how to start the server

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a61671b3c8333a6b4d8257d6e7af1