### PR TITLE
Update software index buttons

### DIFF
--- a/software_index.html
+++ b/software_index.html
@@ -53,24 +53,21 @@
                         <h2 class="software-card-title text-2xl font-semibold mb-3 text-purple-700">M-STAR CFD</h2>
                         <p class="software-description text-gray-600 mb-4 flex-grow">Lattice Boltzmann 기반의 GPU 가속 CFD 소프트웨어로, 대규모 혼합 및 다상 유동 시스템에 특화되어 있습니다.</p>
                         <a href="mstar_cfd_main.html" class="software-index-btn bg-[#0072CE] text-white px-4 py-2 rounded hover:bg-[#004A99] transition-colors mt-auto font-medium">
-                            M-STAR CFD 정보 보기 &raquo;
-                            <span class="learn-more-text block mt-1 text-white/80">자세히 알아보기</span>
+                            <span class="learn-more-text text-white/80">자세히 알아보기</span>
                         </a>
                     </div>
                     <div class="software-card bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-sky-500">
                         <h2 class="software-card-title text-2xl font-semibold mb-3 text-sky-700">Ansys Fluent</h2>
                         <p class="software-description text-gray-600 mb-4 flex-grow">산업 표준 CFD 소프트웨어로, 복잡한 유동, 열 전달, 화학 반응 등 광범위한 물리 현상 해석에 사용됩니다.</p>
                         <a href="ansys_fluent_main.html" class="software-index-btn bg-[#0072CE] text-white px-4 py-2 rounded hover:bg-[#004A99] transition-colors mt-auto font-medium">
-                            Ansys Fluent 정보 보기 &raquo;
-                            <span class="learn-more-text block mt-1 text-white/80">자세히 알아보기</span>
+                            <span class="learn-more-text text-white/80">자세히 알아보기</span>
                         </a>
                     </div>
                     <div class="software-card bg-slate-50 p-6 rounded-lg shadow hover:shadow-lg transition-shadow duration-300 ease-in-out flex flex-col border border-slate-200 hover:border-green-500">
                         <h2 class="software-card-title text-2xl font-semibold mb-3 text-green-700">OpenFOAM</h2>
                         <p class="software-description text-gray-600 mb-4 flex-grow">오픈 소스 CFD 소프트웨어로, 유연성과 확장성이 뛰어나며 다양한 물리 문제 해결에 사용됩니다.</p>
                         <a href="openfoam_main.html" class="software-index-btn bg-[#0072CE] text-white px-4 py-2 rounded hover:bg-[#004A99] transition-colors mt-auto font-medium">
-                            OpenFOAM 정보 보기 &raquo;
-                            <span class="learn-more-text block mt-1 text-white/80">자세히 알아보기</span>
+                            <span class="learn-more-text text-white/80">자세히 알아보기</span>
                         </a>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -809,8 +809,8 @@ h1.main-title {
   align-items: center;
   justify-content: center;
   line-height: 1;
-  /* Visually nudge button text upward for better centering */
-  transform: translateY(-2px);
+  /* Center the button text */
+  transform: translateY(0);
 }
 /* === software-card|UI_TWEAK_END === */
 


### PR DESCRIPTION
## Summary
- remove redundant button text from `software_index.html`
- adjust styles so the `자세히 알아보기` button text stays centered

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684a816dc9e48333b286e245c0ee3739