### PR TITLE
Add Codex pre-PR check to docs and CI

### DIFF
--- a/.github/workflows/codex-verify.yml
+++ b/.github/workflows/codex-verify.yml
@@ -1,0 +1,24 @@
+name: codex-prepr-check
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  codex-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install codex-cli
+        run: npm install -g codex-cli
+      - name: Run Codex dry-run
+        run: codex-cli verify .
+

--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ The site will be available at `http://localhost:3000` by default.
 This project is licensed under the [MIT License](LICENSE).
 
 
+
+## Codex Pre-PR Verification
+모든 PR 작성 전, 저장소 최상단에서 다음 명령으로 Codex 사전 점검을 실시하세요.
+
+```bash
+./scripts/codex-test.sh
+```
+
+Codex 테스트가 실패하면 PR을 제출하지 말고 먼저 문제를 수정해 주세요.
+

--- a/scripts/codex-test.sh
+++ b/scripts/codex-test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+codex-cli verify .


### PR DESCRIPTION
## Summary
- document Codex verification step in README
- add scripts/codex-test.sh for local checking
- run Codex dry-run on all pushes and PRs via GitHub Actions

## Testing
- `./scripts/codex-test.sh` *(fails: codex-cli not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3d15afa88333b280c2cfb6f0156c