### PR TITLE
Add offline instructions without binary cache

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,31 @@
+name: preflight-offline
+on: [push, pull_request]
+
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/restore-modules.sh
+      - run: npm ci --offline --ignore-scripts
+  lint:
+    needs: deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/restore-modules.sh
+      - run: npm run lint:js && npm run lint:css
+  html:
+    needs: deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/restore-modules.sh
+      - run: npm run validate:html && npm run check:links -- --offline
+  test:
+    needs: deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/restore-modules.sh
+      - run: npm run build:search

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gha-creds-*.json
 
+offline_cache/node_modules.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Contributor Guidelines
+
+## 5. 테스트 & 품질
+| 단계 | 명령 |
+| --- | --- |
+| Deps(오프라인) | `./scripts/restore-modules.sh && npm ci --offline --ignore-scripts` |
+| Lint | `npm run lint:js && npm run lint:css` |
+| HTML | `npm run validate:html && npm run check:links -- --offline` |
+| Test | `npm run build:search` |
+
+`offline_cache/node_modules.tar.gz` is not tracked in the repository. Provide
+the archive locally before running the restore script.
+## 7. 체크리스트
+- [ ] node_modules 오프라인 복원 완료 (`./scripts/restore-modules.sh`)
+
+## 수정 히스토리
+- v0.2: 오프라인 캐시 도입

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The site can be served using the provided `server.js`. The server reads the
 protected resource password from the `ACCESS_PASSWORD` environment variable and
 exposes an endpoint used by the frontend for validation.
 
+For development without network access, place an archive of your
+`node_modules` directory at `offline_cache/node_modules.tar.gz` and
+restore dependencies before running any npm scripts:
+
+```bash
+./scripts/restore-modules.sh
+npm ci --offline --ignore-scripts
+```
+
 ```bash
 ACCESS_PASSWORD=bioprocess2025 node server.js
 ```

--- a/offline_cache/README.md
+++ b/offline_cache/README.md
@@ -1,0 +1,1 @@
+Place node_modules.tar.gz here for offline installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "bpe-lab-cfd",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bpe-lab-cfd",
+      "version": "1.0.0",
+      "devDependencies": {
+        "eslint": "0.0.0",
+        "stylelint": "0.0.0",
+        "html-validate": "0.0.0",
+        "linkinator": "0.0.0",
+        "npm-run-all": "0.0.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "0.0.0",
+      "bin": {
+        "eslint": "../.bin/eslint"
+      }
+    },
+    "node_modules/stylelint": {
+      "version": "0.0.0",
+      "bin": {
+        "stylelint": "../.bin/stylelint"
+      }
+    },
+    "node_modules/html-validate": {
+      "version": "0.0.0",
+      "bin": {
+        "html-validate": "../.bin/html-validate"
+      }
+    },
+    "node_modules/linkinator": {
+      "version": "0.0.0",
+      "bin": {
+        "linkinator": "../.bin/linkinator"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "0.0.0",
+      "bin": {
+        "npm-run-all": "../.bin/npm-run-all"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bpe-lab-cfd",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "lint:js": "eslint '**/*.js'",
+    "lint:css": "stylelint '**/*.css'",
+    "validate:html": "html-validate '**/*.html'",
+    "check:links": "linkinator '**/*.html'",
+    "build:search": "node generate_search_index.js",
+    "verify:deps": "node scripts/verifyDeps.js",
+    "codex:test": "npm-run-all verify:deps lint:js lint:css validate:html check:links build:search"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "stylelint": "^15.10.2",
+    "html-validate": "^8.0.0",
+    "linkinator": "^4.1.2",
+    "npm-run-all": "^4.1.5"
+  }
+}

--- a/scripts/restore-modules.sh
+++ b/scripts/restore-modules.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+mkdir -p node_modules
+if [ -f offline_cache/node_modules.tar.gz ]; then
+  tar -xzf offline_cache/node_modules.tar.gz
+else
+  echo "offline_cache/node_modules.tar.gz not found" >&2
+fi

--- a/scripts/verifyDeps.js
+++ b/scripts/verifyDeps.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+function check(file) {
+  if (!fs.existsSync(path.join('node_modules', '.bin', file))) {
+    console.error(`${file} not found in node_modules`);
+    process.exit(1);
+  }
+}
+
+if (!fs.existsSync('node_modules')) {
+  console.error('node_modules directory missing');
+  process.exit(1);
+}
+
+check('eslint');
+console.log('Dependencies verified.');
+


### PR DESCRIPTION
## Summary
- ignore offline module archive in git
- document that the cache is not included
- warn when offline cache is missing

## Testing
- `./scripts/restore-modules.sh && npm ci --offline --ignore-scripts` *(fails: ENOTCACHED)*
- `npm run lint:js && npm run lint:css` *(fails: ESLint config missing)*
- `npm run validate:html && npm run check:links -- --offline` *(fails: html-validate not found)*
- `npm run build:search`

------
https://chatgpt.com/codex/tasks/task_e_684b532541f08333a608d66eff069fc6