### PR TITLE
Update README and AGENTS for CDN fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,31 +1,49 @@
-# Project Guidelines
+## 1. Purpose
+This project hosts offline-accessible static content for the BPE-Lab CFD website.
 
-## Purpose
-This project provides offline-accessible static educational content for the BPE-Lab CFD website.
+## 2. Folder Structure
+  - `css/tailwind.offline.css`  Tailwind offline fallback
+  - `assets/js/libs/`           third-party scripts
 
-## Folder Structure
-- `index.html` entry point
-- `css/tailwind.min.css` Tailwind CSS (local copy)
-- `css/style.css` custom styles
-- `js/script.js` main JavaScript
-- `js/vendor/` third party scripts
-- `assets/` images and fonts
+## 3. Coding Style
+  - Prefer Tailwind utilities; custom CSS in style.css
 
-## Coding Style
-- Use descriptive class names where custom CSS is required.
-- Reuse Tailwind utility classes when possible to keep CSS minimal.
+## 4. Pull Request Rules
+  - Tags: [Feat] [Fix] [Docs] [Infra] [Chore]
+  - Example: [Infra] add bg-video fallback  (Closes #42)
 
-## Pull Request Rules
-- Title must start with `[Feat]`, `[Fix]`, or `[Docs]` as appropriate.
-- Provide a short summary and include a "Testing Done" section describing manual and CI test results.
+## 5. Offline / Online Strategy
+  ▸ **CDN link는 삭제 금지**.  
+  ▸ CDN 바로 아래 `<link rel="stylesheet" href="css/tailwind.offline.css" onerror="this.onerror=null;this.media='all'">`  
+    및 Pretendard offline link 삽입.  
+  ▸ `<noscript data-offline>` 패턴은 **JS completely disabled** 상황에서만 보조적으로 사용.  
+  ▸ *중복* `style.css` link 발견 시 Codex는 첫 하나만 남긴다.  
+  ▸ `tailwind.offline.css` 생성 규칙  
+    - 포함: reset, container, flex, grid, typography utilities  
+    - 제외: animation, shadow, ring, motion-related utilities  
+    - 최종 파일 ≤ 30 KB  
+  ▸ Pretendard Fallback  
+    - 기본: `body{font-family:sans-serif}`  
+    - 필요 시 `assets/fonts/Pretendard-Variable.otf` 1 파일을 두고 @font-face 선언.  
+  ▸ 새 CDN 라이브러리 도입 시 동일 “CDN + Fallback(onerror)” 패턴 적용.
 
-## Manual Testing
-`python3 -m http.server → 브라우저 확인 (index.html 200 OK)`
+## 6. Manual Testing
+```bash
+python3 -m http.server &                   # launch local server
+curl -s http://localhost:8000 | grep -q 'tailwind.offline.css' && \
+curl -I  http://localhost:8000/index.html | grep -q '200 OK' && \
+test -f assets/videos/placeholder.mp4 && \
+echo "PASS"
+kill $!                                     # stop server
+```
 
-## 5. 테스트 & 품질
+## 7. History
 
-## 6. 수정 히스토리
-- v0.2 — YYYY-MM-DD : static tool bootstrap
-- v0.3 — YYYY-MM-DD : remove unused tool references
+* v0.4 — 2025-06-13 : add flexible CDN/Fallback policy
 
-## 7. 체크리스트
+## 8. Checklist
+
+* [ ] Duplicate `style.css` link 없는가
+* [ ] tailwind.offline.css ≤ 30 KB
+* [ ] placeholder.mp4 ≤ 200 KB
+* [ ] Manual Testing 스크립트 통과

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repository hosts materials for the BPE-Lab CFD website.
 
+## Architecture
+| Environment            | Resource loading strategy                           |
+|------------------------|-----------------------------------------------------|
+| Online (GitHub Pages)  | Tailwind CDN · Pretendard CDN · real video.mp4      |
+| Offline (Codex sandbox)| CDN fails ➜ Fallback CSS (`tailwind.offline.css`,   |
+|                        | `pretendard.offline.css`) and poster.jpg via        |
+|                        | **link onerror** trigger                            |
+
+<!-- *오프라인 컨테이너는 JS 차단 상태일 수도 있으나, CDN 404 상황까지 아우르기 위해 onerror 방식을 기본값으로 채택합니다.* -->
+
 ## Local Development
 
 The site can be served using the provided `server.js`. The server reads the
@@ -13,17 +23,21 @@ ACCESS_PASSWORD=bioprocess2025 node server.js
 ```
 
 The site will be available at `http://localhost:3000` by default.
- 
 
-## Contributing
-
-For offline development, run:
-
-```bash
-python3 -m http.server
+## Folder Structure
+```
+index.html
+css/
+  ├─ style.css                 # project-specific
+  ├─ tailwind.offline.css      # offline fallback (≤ 30 KB, see AGENTS)
+  └─ pretendard.offline.css    # offline fallback
+assets/
+  ├─ js/libs/                  # third-party JS
+  └─ videos/                   # bg videos (placeholder & real, ≤ 200 KB/ea)
 ```
 
-
+## Contributing
+로컬 확인 : python3 -m http.server → http://localhost:8000
 
 ## License
 


### PR DESCRIPTION
## Summary
- document CDN + fallback strategy
- describe updated folder structure and PR rules

## Testing
- `python3 -m http.server` *(fails: assets/videos/placeholder.mp4 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684bbba8540083339554d6e3c0a54f9e