### PR TITLE
[Feat] default password fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ This repository hosts materials for the BPE-Lab CFD website.
 
 The site can be served using the provided `server.js`. The server reads the
 protected resource password from the `ACCESS_PASSWORD` environment variable and
-exposes an endpoint used by the frontend for validation.
+exposes an endpoint used by the frontend for validation. If no environment
+variable is specified, the password defaults to `bioprocess2025`.
 
 ```bash
-ACCESS_PASSWORD=bioprocess2025 node server.js
+node server.js                # uses default password
+# or override
+ACCESS_PASSWORD=secret node server.js
 ```
 
 The site will be available at `http://localhost:3000` by default.

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 
 const app = express();
-const PASSWORD = process.env.ACCESS_PASSWORD;
+const PASSWORD = process.env.ACCESS_PASSWORD || 'bioprocess2025';
 
 app.use(express.json());
 app.use(express.static(__dirname));


### PR DESCRIPTION
## Summary
- allow running server without ACCESS_PASSWORD
- document default password usage in README

## Testing
- `python3 -m http.server &` *(fails: placeholder.mp4 missing)*
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_684beba9dd608333b6941e96bc101673