### PR TITLE
Fix password workflow

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -646,6 +646,6 @@
     "id": "resources",
     "name_ko": "자료실",
     "name_en": "Resources",
-    "path": "lab_resources.html"
+    "path": "password.html"
   }
 ]

--- a/password.html
+++ b/password.html
@@ -9,12 +9,52 @@
     <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/pretendard.offline.css" onerror="this.onerror=null;this.media='all'">
     <link href="style.css" rel="stylesheet">
-    <script src="https://unpkg.com/lucide@latest"></script>
 </head>
-<body class="font-pretendard bg-gray-50 text-gray-800">
-    <script src="script.js"></script>
+<body class="font-pretendard">
+    <div id="passwordOverlay">
+        <div id="overlayContent">
+            <div id="loadingSpinner" class="spinner"></div>
+            <p style="color:#fff; font-size:16px;">비밀번호를 입력하세요 <span>(대소문자 구분)</span></p>
+            <input type="password" id="passwordInput" class="password-input" placeholder="비밀번호 입력" />
+            <p id="passwordError" class="text-red-500 mt-2" style="display:none;"></p>
+            <div class="password-buttons mt-2">
+                <button id="passwordSubmit" class="mr-2 bg-blue-600 text-white px-3 py-1 rounded">확인</button>
+                <button id="passwordCancel" class="bg-gray-300 text-gray-800 px-3 py-1 rounded">취소</button>
+            </div>
+        </div>
+    </div>
+
     <script>
-        document.addEventListener('DOMContentLoaded', showPasswordModal);
+    document.addEventListener('DOMContentLoaded', () => {
+        const encodedPassword = 'YmlvcHJvY2VzczIwMjU=';
+        const correctPassword = atob(encodedPassword);
+        const input = document.getElementById('passwordInput');
+        const error = document.getElementById('passwordError');
+
+        function handleSubmit() {
+            const pw = input.value.trim();
+            if (pw === correctPassword) {
+                localStorage.setItem('authed', 'ok');
+                const next = localStorage.getItem('next') || 'lab_resources.html';
+                window.location.href = next;
+            } else {
+                error.textContent = '비밀번호가 틀렸습니다. 대소문자를 정확히 입력해주세요.';
+                error.style.display = 'block';
+                input.focus();
+            }
+        }
+
+        document.getElementById('passwordSubmit').addEventListener('click', handleSubmit);
+        input.addEventListener('keyup', e => { if (e.key === 'Enter') handleSubmit(); });
+        document.getElementById('passwordCancel').addEventListener('click', () => {
+            if (window.history.length > 1) {
+                window.history.back();
+            } else {
+                window.location.href = 'index.html';
+            }
+        });
+        input.focus();
+    });
     </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -106,51 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function showPasswordModal(event) {
-        if (event) event.preventDefault();
-        const overlay = document.createElement('div');
-        overlay.id = 'passwordOverlay';
-        overlay.innerHTML = `
-            <div id="overlayContent">
-                <div id="loadingSpinner" class="spinner"></div>
-                <p data-i18n="enter_password" style="color:#fff; font-size:16px;">${jsI18n.enter_password}</p>
-                <input type="password" id="passwordInput" class="password-input" placeholder="${jsI18n.password_placeholder}" data-i18n="password_placeholder" />
-                <p id="passwordError" class="text-red-500 mt-2" style="display:none;"></p>
-                <div class="password-buttons mt-2">
-                    <button id="passwordSubmit" class="mr-2 bg-blue-600 text-white px-3 py-1 rounded" data-i18n="confirm_button">${jsI18n.confirm_button}</button>
-                    <button id="passwordCancel" class="bg-gray-300 text-gray-800 px-3 py-1 rounded" data-i18n="cancel_button">${jsI18n.cancel_button}</button>
-                </div>
-            </div>`;
-        document.body.appendChild(overlay);
-        document.getElementById('passwordSubmit').addEventListener('click', checkPassword);
-        document.getElementById('passwordCancel').addEventListener('click', closeOverlay);
-        document.getElementById('passwordInput').addEventListener('keyup', e => {
-            if (e.key === 'Enter') checkPassword();
-        });
-        document.getElementById('passwordInput').focus();
-    }
-
-    function checkPassword() {
-        const pw = document.getElementById('passwordInput').value.trim();
-        if (pw === 'bioprocess2025') {
-            localStorage.setItem('authed', 'ok');
-            const next = localStorage.getItem('next') || '/library/';
-            location.href = next;
-        } else {
-            const err = document.getElementById('passwordError');
-            if (err) err.style.display = 'block';
-        }
-    }
-
-    function closeOverlay() {
-        const overlay = document.getElementById('passwordOverlay');
-        if (overlay) overlay.remove();
-        if (window.history.length > 1) {
-            window.history.back();
-        } else {
-            window.location.href = 'index.html';
-        }
-    }
+    
 
     const defaultTexts = { ...jsI18n };
 
@@ -692,15 +648,7 @@ document.addEventListener('DOMContentLoaded', () => {
         observer.observe(sentinel);
     }
 
-    const resourcesMenuLink = document.querySelector('li[data-menu="resources"] > a');
-    if (resourcesMenuLink) {
-        resourcesMenuLink.addEventListener('click', e => {
-            if (localStorage.getItem('authed') === 'ok') return;
-            e.preventDefault();
-            localStorage.setItem('next', resourcesMenuLink.getAttribute('href'));
-            showPasswordModal(e);
-        });
-    }
+
 
     const searchInput = document.getElementById('searchInput');
     const searchButton = document.getElementById('searchButton');

--- a/search_index.json
+++ b/search_index.json
@@ -2295,14 +2295,14 @@
         "title": "비밀번호 입력",
         "breadcrumb": [
             "홈",
-            "비밀번호 입력"
+            "자료실"
         ],
         "keywords": [
             "비밀번호",
             "입력"
         ],
-        "content_snippet": "",
-        "full_text": "document.addEventListener('DOMContentLoaded', showPasswordModal);"
+        "content_snippet": "비밀번호를 입력하세요 (대소문자 구분)",
+        "full_text": "비밀번호를 입력하세요 (대소문자 구분) 확인 취소 document.addEventListener('DOMContentLoaded', () => { const encodedPassword = 'YmlvcHJvY2VzczIwMjU='; const correctPassword = atob(encodedPassword); const input = document.getElementById('passwordInput'); const error = document.getElementById('passwordError'); function handleSubmit() { const pw = input.value.trim(); if (pw === correctPassword) { localStorage.setItem('authed', 'ok'); const next = localStorage.getItem('next') || 'lab_resources.html'; window.location.href = next; } else { error.textContent = '비밀번호가 틀렸습니다. 대소문자를 정확히 입력해주세요.'; error.style.display = 'block'; input.focus(); } } document.getElementById('passwordSubmit').addEventListener('click', handleSubmit); input.addEventListener('keyup', e => { if (e.key === 'Enter') handleSubmit(); }); document.getElementById('passwordCancel').addEventListener('click', () => { if (window.history.length > 1) { window.history.back(); } else { window.location.href = 'index.html'; } }); input.focus(); });"
     },
     {
         "url": "photo_gallery.html",


### PR DESCRIPTION
## Summary
- update menu to send Resources to `password.html`
- inline password prompt markup and logic on `password.html`
- remove old modal and click handlers from `script.js`

## Testing
- `python3 -m http.server &`
- `curl -s http://localhost:8000 | grep -q 'tailwind.offline.css' && curl -I http://localhost:8000/index.html | grep -q '200 OK' && test -f assets/videos/placeholder.mp4 && echo "PASS"`


------
https://chatgpt.com/codex/tasks/task_e_684c02f685288333ba17214e060eac5c