### PR TITLE
[Fix] pin notes header and export tsv

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -205,7 +205,7 @@ function downloadCSV(){
   const blob=new Blob([lines.join('\n')],{type:'text/tab-separated-values'});
   const a=document.createElement('a');
   a.href=URL.createObjectURL(blob);
-  a.download='notes.csv';
+  a.download='notes.tsv';
   a.click();
   URL.revokeObjectURL(a.href);
 }

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -40,14 +40,14 @@ nav_order: 2
   <button id="downloadCSV" class="text-sm text-blue-600 underline" aria-label="CSV 다운로드">CSV 다운로드</button>
   <button id="clearNotes" class="text-sm text-red-600 underline" aria-label="전체 삭제">전체 삭제</button>
 </div>
-<div id="notes" class="space-y-1"></div>
-<div id="notesHeader" class="log-row font-semibold bg-gray-100 mt-4 py-1">
+<div id="notesHeader" class="log-row font-semibold bg-gray-100 mb-4 py-1">
   <span class="seq">Index</span>
   <span class="meta">Timestamp / ID / Sheet No.</span>
   <span class="data flex-1">Details</span>
 </div>
+<div id="notes" class="space-y-1"></div>
 
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
-<script src="{{ '/assets/js/cfd-stat-simple.js' | relative_url }}?v=2"></script>
+<script src="{{ '/assets/js/cfd-stat-simple.js' | relative_url }}?v=3"></script>


### PR DESCRIPTION
## Summary
- keep the notes summary row fixed above the log list
- export notes as TSV when downloading

## Testing
- `python3 -m http.server &` and basic checks

------
https://chatgpt.com/codex/tasks/task_e_684c0c271d1c8333b8c016267f96b1c1