### PR TITLE
[Feat] handle multi-sheet warning and new ID rule

### DIFF
--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -9,12 +9,13 @@ nav_order: 2
 
 <h1 class="text-2xl font-bold mb-2">CFD Data Summary Analyzer</h1>
 <div class="mb-4 text-sm text-gray-600 space-y-1">
+  <p><strong>첨부 가능한 파일은 하나의 시트만 포함된 Excel(xlsx)·CSV·TXT 파일이어야 합니다.</strong></p>
   <p><strong>첨부 가능한 파일 형식:</strong> .txt, .csv, .xlsx</p>
   <p><strong>파일 형식:</strong> 첫 행은 헤더, 첫 열은 시간 데이터여야 합니다.</p>
   <p><strong>사이클 정의:</strong> 1 cycle = 60 / RPM (초)로 계산합니다.</p>
   <p><strong>데이터 범위:</strong> 입력한 마지막 N개 사이클만 평균 계산에 사용됩니다.</p>
   <p><strong>아웃라이어 제거:</strong> IQR 방식으로 이상치를 제거합니다.</p>
-  <p><strong>ID 생성:</strong> 파일 이름의 앞 두 글자와 마지막 두 글자를 결합합니다.</p>
+  <p><strong>ID 생성:</strong> 파일 이름에서 특수문자를 제외한 앞 6자와 뒤 6자를 조합합니다. 파일명이 짧은 경우 전체 이름을 사용합니다.</p>
 </div>
 <div id="drop" tabindex="0" role="button" aria-label="파일 업로드 영역" class="mb-4">여기로 파일을 끌어오거나 클릭하여 첨부</div>
 <input id="file" type="file" accept=".xlsx,.xls,.csv,.txt" hidden>
@@ -22,6 +23,7 @@ nav_order: 2
   <span id="fileName"></span>
   <button id="removeFile" aria-label="첨부 파일 제거" class="hidden"><i data-lucide="x"></i></button>
 </div>
+<div id="sheetWarning" class="hidden mb-4 p-2 bg-yellow-100 text-yellow-800 rounded text-sm"></div>
 
 <div id="inputSection" class="hidden mb-4">
   <div class="flex flex-col sm:flex-row gap-2 items-center">
@@ -42,7 +44,7 @@ nav_order: 2
 </div>
 <div id="notesHeader" class="log-row font-semibold bg-gray-100 mb-4 py-1">
   <span class="seq">Index</span>
-  <span class="meta">Timestamp / ID / Sheet No.</span>
+  <span class="meta">Timestamp / ID</span>
   <span class="data flex-1">Details</span>
 </div>
 <div id="notes" class="space-y-1"></div>

--- a/search_index.json
+++ b/search_index.json
@@ -1118,7 +1118,7 @@
         "keywords": [
             "cfd_statisticshtml"
         ],
-        "content_snippet": "첨부 가능한 파일 형식: .txt, .csv, .xlsx",
+        "content_snippet": "첨부 가능한 파일은 하나의 시트만 포함된 Excel(xlsx)·CSV·TXT 파일이어야 합니다.",
         "full_text": ""
     },
     {


### PR DESCRIPTION
## Summary
- warn when multiple sheets are found and use only the first sheet
- update ID generation rules
- remove sheet number from note logs and CSV export
- mention single-sheet requirement in instructions

## Testing
- `python3 -m http.server &` then run manual checks
- `curl -s http://localhost:8000 | grep -q 'tailwind.offline.css' && curl -I  http://localhost:8000/index.html | grep -q '200 OK' && test -f assets/videos/placeholder.mp4 && echo "PASS"`
- `chromium --headless --window-size=375,800 http://localhost:8000 -s /tmp/mobile.png && identify -format "%h" /tmp/mobile.png | grep -q '[1-9]'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c16bc9d588333bebddedbacfe83e5