### PR TITLE
[Fix] download CSV extension

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -213,10 +213,10 @@ function downloadCSV(){
     row.push(...n.values);
     lines.push(row.join('\t'));
   });
-  const blob=new Blob([lines.join('\n')],{type:'text/tab-separated-values'});
+  const blob=new Blob([lines.join('\n')],{type:'text/csv'});
   const a=document.createElement('a');
   a.href=URL.createObjectURL(blob);
-  a.download='notes.tsv';
+  a.download='notes.csv';
   a.click();
   URL.revokeObjectURL(a.href);
 }


### PR DESCRIPTION
## Summary
- output notes as `notes.csv` instead of `.tsv`

## Testing
- `python3 -m http.server` + `curl`

------
https://chatgpt.com/codex/tasks/task_e_684c1ea4e2348333a731160429e404d5