### PR TITLE
[Fix] export notes as TSV text

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -10,7 +10,7 @@ const resultsBox = document.getElementById('results');
 const notesBox = document.getElementById('notes');
 const removeBtn = document.getElementById('removeFile');
 const clearBtn = document.getElementById('clearNotes');
-const csvBtn = document.getElementById('downloadCSV');
+const tsvBtn = document.getElementById('downloadTSV');
 const sheetWarn = document.getElementById('sheetWarning');
 let currentFile;
 
@@ -29,7 +29,7 @@ drop.addEventListener('click',()=>fileInput.click());
 fileInput.addEventListener('change',e=>handleFile(e.target.files[0]));
 removeBtn.addEventListener('click',clearFile);
 clearBtn.addEventListener('click',clearNotes);
-csvBtn.addEventListener('click',downloadCSV);
+tsvBtn.addEventListener('click',downloadTSV);
 
 function handleFile(f){
   if(!f) return;
@@ -201,7 +201,7 @@ function clearNotes(){
   renderNotes();
 }
 
-function downloadCSV(){
+function downloadTSV(){
   const notes=JSON.parse(localStorage.getItem('cfdStatsNotes')||'[]');
   if(!notes.length) return;
   const maxCols=Math.max(...notes.map(n=>n.values.length));
@@ -219,7 +219,7 @@ function downloadCSV(){
   );
   const a=document.createElement('a');
   a.href=URL.createObjectURL(blob);
-  a.download='notes.csv';
+  a.download='notes.tsv';
   a.click();
   URL.revokeObjectURL(a.href);
 }

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -39,7 +39,7 @@ nav_order: 2
 
 <h2 class="text-xl font-semibold mt-8">노트</h2>
 <div class="flex gap-2 mt-2 mb-1">
-  <button id="downloadCSV" class="text-sm text-blue-600 underline" aria-label="CSV 다운로드">CSV 다운로드</button>
+  <button id="downloadTSV" class="text-sm text-blue-600 underline" aria-label="TSV 다운로드">TSV 다운로드</button>
   <button id="clearNotes" class="text-sm text-red-600 underline" aria-label="전체 삭제">전체 삭제</button>
 </div>
 <div id="notesHeader" class="log-row font-semibold bg-gray-100 mb-4 py-1">


### PR DESCRIPTION
## Summary
- rename `CSV 다운로드` button to `TSV 다운로드`
- change download function to export `notes.tsv`

## Testing
- `python3 -m http.server &`
- `curl -s http://localhost:8000 | grep -q 'tailwind.offline.css'`
- `curl -I http://localhost:8000/index.html | grep -q '200 OK'`
- `test -f assets/videos/placeholder.mp4`


------
https://chatgpt.com/codex/tasks/task_e_684c2431f4e08333b21f3464059159ec