### PR TITLE
[Fix] change notes download extension

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -219,7 +219,7 @@ function downloadTSV(){
   );
   const a=document.createElement('a');
   a.href=URL.createObjectURL(blob);
-  a.download='notes.tsv';
+  a.download='notes.txt';
   a.click();
   URL.revokeObjectURL(a.href);
 }

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -39,7 +39,7 @@ nav_order: 2
 
 <h2 class="text-xl font-semibold mt-8">노트</h2>
 <div class="flex gap-2 mt-2 mb-1">
-  <button id="downloadTSV" class="text-sm text-blue-600 underline" aria-label="TSV 다운로드">TSV 다운로드</button>
+  <button id="downloadTSV" class="text-sm text-blue-600 underline" aria-label="TXT 다운로드">TXT 다운로드</button>
   <button id="clearNotes" class="text-sm text-red-600 underline" aria-label="전체 삭제">전체 삭제</button>
 </div>
 <div id="notesHeader" class="log-row font-semibold bg-gray-100 mb-4 py-1">


### PR DESCRIPTION
## Summary
- ensure the statistics notes file downloads as `notes.txt`
- update the button label to match

## Testing
- `python3 -m http.server &` and curl checks

------
https://chatgpt.com/codex/tasks/task_e_684c2735dc748333abf5151fb51c6de5