### PR TITLE
Fix resource link path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This project hosts offline-accessible static content for the BPE-Lab CFD website
 ## 3. Coding Style
   - Prefer Tailwind utilities; custom CSS in style.css
   - 기본은 모바일(≤ 768 px) 기준; 'md:'(≥ 768 px) 이상에서 PC 확장.
+  - GitHub Pages 환경을 고려해 내부 링크는 `/example.html`처럼 절대경로를
+    사용하지 말고 `example.html` 같은 상대경로로 작성할 것.
 
 ## 4. Pull Request Rules
   - Tags: [Feat] [Fix] [Docs] [Infra] [Chore]

--- a/lab_resources.html
+++ b/lab_resources.html
@@ -11,7 +11,7 @@
     <script>
       if (localStorage.getItem('authed') !== 'ok') {
         localStorage.setItem('next', location.pathname);
-        location.href = '/password.html';
+        location.href = 'password.html';
       }
     </script>
 </head>

--- a/menu.json
+++ b/menu.json
@@ -646,6 +646,6 @@
     "id": "resources",
     "name_ko": "자료실",
     "name_en": "Resources",
-    "path": "password.html"
+  "path": "lab_resources.html"
   }
 ]

--- a/resources.html
+++ b/resources.html
@@ -11,7 +11,7 @@
     <script>
       if (localStorage.getItem('authed') !== 'ok') {
         localStorage.setItem('next', location.pathname);
-        location.href = '/password.html';
+        location.href = 'password.html';
       }
     </script>
 </head>

--- a/script.js
+++ b/script.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (currentPage === 'lab_resources.html' || currentPage === 'resources.html') {
         if (localStorage.getItem('authed') !== 'ok') {
             localStorage.setItem('next', location.pathname);
-            window.location.href = '/password.html';
+            window.location.href = 'password.html';
             return;
         }
     }


### PR DESCRIPTION
## Summary
- fix nav auth redirect to use relative path
- update resource pages to use relative path
- sync `menu.json`
- document relative link guidance

## Testing
- `python3 -m http.server &`
- `curl -s http://localhost:8000 | grep -q 'tailwind.offline.css' && curl -I http://localhost:8000/index.html | grep -q '200 OK' && test -f assets/videos/placeholder.mp4 && echo "PASS"`


------
https://chatgpt.com/codex/tasks/task_e_6850267ea2b88333857eee36c13e786f