### PR TITLE
Add manual ID input option

### DIFF
--- a/_layouts/tool.html
+++ b/_layouts/tool.html
@@ -5,9 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title }} - 생물공학연구실</title>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link rel="stylesheet" href="{{ '/css/tailwind.offline.css' | relative_url }}" onerror="this.onerror=null;this.media='all'">
     <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ '/css/pretendard.offline.css' | relative_url }}" onerror="this.onerror=null;this.media='all'">
     <link href="{{ '/style.css' | relative_url }}" rel="stylesheet">
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@latest" onerror="this.onerror=null;this.src='{{ '/assets/js/libs/lucide.offline.js' | relative_url }}'"></script>
 </head>
 <body class="font-pretendard bg-gray-50 text-gray-800 flex flex-col min-h-screen">
 

--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -5,6 +5,8 @@ const rpmInput = document.getElementById('rpm');
 const cycleInput = document.getElementById('cycle');
 const precInput = document.getElementById('precision');
 const outlierChk = document.getElementById('outlier');
+const manualChk = document.getElementById('manualIdChk');
+const manualIdInput = document.getElementById('manualIdInput');
 const analyzeBtn = document.getElementById('analyze');
 const resultsBox = document.getElementById('results');
 const notesBox = document.getElementById('notes');
@@ -30,6 +32,13 @@ fileInput.addEventListener('change',e=>handleFile(e.target.files[0]));
 removeBtn.addEventListener('click',clearFile);
 clearBtn.addEventListener('click',clearNotes);
 tsvBtn.addEventListener('click',downloadTSV);
+manualChk.addEventListener('change',()=>{
+  if(manualChk.checked){
+    manualIdInput.classList.remove('hidden');
+  }else{
+    manualIdInput.classList.add('hidden');
+  }
+});
 
 function handleFile(f){
   if(!f) return;
@@ -152,7 +161,14 @@ function saveNote(values){
   const ts = dayjs().format('YYMMDD-HH:mm');
   const name = currentFile.name.replace(/\.[^.]+$/,'');
   const cleaned = name.replace(/[^A-Za-z0-9가-힣]/g,'');
-  const id = cleaned.length<=12 ? cleaned : cleaned.slice(0,6)+cleaned.slice(-6);
+  let id;
+  if(manualChk.checked && manualIdInput.value.trim()){
+    const manualVal = manualIdInput.value.trim();
+    const cleanedManual = manualVal.replace(/[^A-Za-z0-9가-힣]/g,'');
+    id = cleanedManual.length ? cleanedManual : manualVal;
+  }else{
+    id = cleaned.length<=12 ? cleaned : cleaned.slice(0,6)+cleaned.slice(-6);
+  }
   const note={ts,id,values};
   const notes=JSON.parse(localStorage.getItem('cfdStatsNotes')||'[]');
   notes.push(note);

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -15,7 +15,7 @@ nav_order: 2
   <p><strong>사이클 정의:</strong> 1 cycle = 60 / RPM (초)로 계산합니다.</p>
   <p><strong>데이터 범위:</strong> 입력한 마지막 N개 사이클만 평균 계산에 사용됩니다.</p>
   <p><strong>아웃라이어 제거:</strong> IQR 방식으로 이상치를 제거합니다.</p>
-  <p><strong>ID 생성:</strong> 파일 이름에서 특수문자를 제외한 앞 6자와 뒤 6자를 조합합니다. 파일명이 짧은 경우 전체 이름을 사용합니다.</p>
+  <p><strong>ID 생성:</strong> 파일 이름에서 특수문자를 제외한 앞 6자와 뒤 6자를 조합합니다. 파일명이 짧은 경우 전체 이름을 사용합니다. 또는 'ID 수동 입력' 항목을 선택해 수동으로 입력한 ID를 사용할 수 있습니다.</p>
 </div>
 <div id="drop" tabindex="0" role="button" aria-label="파일 업로드 영역" class="mb-4">여기로 파일을 끌어오거나 클릭하여 첨부</div>
 <input id="file" type="file" accept=".xlsx,.xls,.csv,.txt" hidden>
@@ -31,6 +31,8 @@ nav_order: 2
     <label>사이클 <input id="cycle" type="number" class="border rounded px-2 py-1 w-24"></label>
     <label>소수 자리 <input id="precision" type="number" value="3" class="border rounded px-2 py-1 w-20"></label>
     <label class="flex items-center"><input id="outlier" type="checkbox" class="mr-1">아웃라이어 제거</label>
+    <label class="flex items-center"><input id="manualIdChk" type="checkbox" class="mr-1">ID 수동 입력</label>
+    <input id="manualIdInput" type="text" class="border rounded px-2 py-1 w-24 hidden">
     <button id="analyze" class="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50" disabled aria-label="분석 실행">분석</button>
   </div>
 </div>
@@ -52,4 +54,4 @@ nav_order: 2
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
-<script src="{{ '/assets/js/cfd-stat-simple.js' | relative_url }}?v=3"></script>
+<script src="{{ '/assets/js/cfd-stat-simple.js' | relative_url }}?v=4"></script>


### PR DESCRIPTION
## Summary
- allow manual ID input in CFD statistics tool
- show manual ID checkbox and input field
- document the manual option in instructions
- ensure offline fallbacks included for Tool layout

## Testing
- `python3 -m http.server` and run offline checks

------
https://chatgpt.com/codex/tasks/task_e_685032d6b1d48333a9c37156166c426a