### PR TITLE
[Fix] add minimal XLSX parser for offline

### DIFF
--- a/assets/js/cfd-stat-simple.js
+++ b/assets/js/cfd-stat-simple.js
@@ -85,35 +85,48 @@ function parseFile(f){
     sheetWarn.classList.add('hidden');
     Papa.parse(f,{header:false,dynamicTyping:true,skipEmptyLines:true,complete:res=>processData(res.data)});
   }else if(ext==='xlsx' || ext==='xls'){
-    f.arrayBuffer().then(buf=>{
-      let wb;
-      try{
-        const data=new Uint8Array(buf);
-        wb=XLSX.read(data,{type:'array'});
-      }catch(e){
+    if(window.XLSX && XLSX.read){
+      f.arrayBuffer().then(buf=>{
+        let wb;
         try{
-          let binary='';
-          const bytes=new Uint8Array(buf);
-          for(let i=0;i<bytes.length;i++) binary+=String.fromCharCode(bytes[i]);
-          wb=XLSX.read(binary,{type:'binary'});
-        }catch(e2){
-          console.error('XLSX read error',e2);
-          throw e2;
+          const data=new Uint8Array(buf);
+          wb=XLSX.read(data,{type:'array'});
+        }catch(e){
+          try{
+            let binary='';
+            const bytes=new Uint8Array(buf);
+            for(let i=0;i<bytes.length;i++) binary+=String.fromCharCode(bytes[i]);
+            wb=XLSX.read(binary,{type:'binary'});
+          }catch(e2){
+            console.error('XLSX read error',e2);
+            throw e2;
+          }
         }
-      }
-      if(wb.SheetNames.length>1){
-        sheetWarn.textContent='⚠ 여러 시트가 포함된 파일입니다. 첫 번째 시트만 분석됩니다.';
+        if(wb.SheetNames.length>1){
+          sheetWarn.textContent='⚠ 여러 시트가 포함된 파일입니다. 첫 번째 시트만 분석됩니다.';
+          sheetWarn.classList.remove('hidden');
+        } else {
+          sheetWarn.classList.add('hidden');
+        }
+        const ws = wb.Sheets[wb.SheetNames[0]];
+        const arr = XLSX.utils.sheet_to_json(ws,{header:1,blankRows:false});
+        processData(arr);
+      }).catch(()=>{
+        sheetWarn.textContent='⚠ 파일을 불러오는 중 문제가 발생했습니다. 파일을 다시 저장하거나 CSV 형식으로 변환해 보세요.';
         sheetWarn.classList.remove('hidden');
-      } else {
+      });
+    }else if(window.SimpleXLSX){
+      SimpleXLSX.parse(f).then(arr=>{
         sheetWarn.classList.add('hidden');
-      }
-      const ws = wb.Sheets[wb.SheetNames[0]];
-      const arr = XLSX.utils.sheet_to_json(ws,{header:1,blankRows:false});
-      processData(arr);
-    }).catch(()=>{
-      sheetWarn.textContent='⚠ 파일을 불러오는 중 문제가 발생했습니다. 파일을 다시 저장하거나 CSV 형식으로 변환해 보세요.';
+        processData(arr);
+      }).catch(()=>{
+        sheetWarn.textContent='⚠ 파일을 불러오는 중 문제가 발생했습니다. 파일을 다시 저장하거나 CSV 형식으로 변환해 보세요.';
+        sheetWarn.classList.remove('hidden');
+      });
+    }else{
+      sheetWarn.textContent='⚠ XLSX 파일을 처리할 수 없습니다.';
       sheetWarn.classList.remove('hidden');
-    });
+    }
   }else{
     sheetWarn.textContent='⚠ 지원되지 않는 파일 형식입니다. .txt, .csv, .xls, .xlsx 파일만 업로드 가능합니다.';
     sheetWarn.classList.remove('hidden');

--- a/assets/js/simple-xlsx.js
+++ b/assets/js/simple-xlsx.js
@@ -1,0 +1,70 @@
+// Minimal XLSX reader for single-sheet files using browser DecompressionStream
+// Returns sheet data as array of rows (array of cell values)
+window.SimpleXLSX = { parse };
+
+async function parse(file){
+  const buf = await file.arrayBuffer();
+  const files = await unzip(buf);
+  const dec = s=>new TextDecoder().decode(s);
+  const wb = dec(files['xl/workbook.xml']);
+  const wbDoc = new DOMParser().parseFromString(wb,'application/xml');
+  const sheetEl = wbDoc.querySelector('sheets sheet');
+  if(!sheetEl) throw new Error('No sheet');
+  const rid = sheetEl.getAttribute('r:id');
+  const relsDoc = new DOMParser().parseFromString(dec(files['xl/_rels/workbook.xml.rels']),'application/xml');
+  let target = relsDoc.querySelector(`Relationship[Id="${rid}"]`).getAttribute('Target');
+  if(!target.startsWith('xl/')) target = 'xl/' + target.replace(/^\/?/, '');
+  const sheetXML = dec(files[target]);
+  const shared = files['xl/sharedStrings.xml'] ? parseShared(dec(files['xl/sharedStrings.xml'])) : [];
+  return parseSheet(sheetXML, shared);
+}
+
+function parseShared(xml){
+  const doc = new DOMParser().parseFromString(xml,'application/xml');
+  return Array.from(doc.getElementsByTagName('si')).map(si=>si.textContent);
+}
+
+function colIndex(ref){
+  let col=0; for(let i=0;i<ref.length;i++){ const c=ref.charCodeAt(i); if(c>=65&&c<=90){ col=col*26+(c-64); } else break; } return col-1;
+}
+
+function parseSheet(xml, shared){
+  const doc = new DOMParser().parseFromString(xml,'application/xml');
+  const rows=[]; let max=0;
+  doc.querySelectorAll('sheetData row').forEach(rowEl=>{
+    const r=parseInt(rowEl.getAttribute('r'))-1;
+    const cells=[];
+    rowEl.querySelectorAll('c').forEach(cel=>{
+      const idx = colIndex(cel.getAttribute('r'));
+      const vEl = cel.getElementsByTagName('v')[0];
+      let v = vEl ? vEl.textContent : '';
+      if(cel.getAttribute('t')==='s') v = shared[parseInt(v,10)] || '';
+      else v = v===''?null:Number(v);
+      cells[idx]=isNaN(v)?v:Number(v);
+      if(idx>max) max=idx;
+    });
+    rows[r]=cells;
+  });
+  return rows.map(r=>{const a=new Array(max+1).fill(null); if(r) r.forEach((v,i)=>{a[i]=v;}); return a;});
+}
+
+async function unzip(buf){
+  const view=new DataView(buf); const u8=new Uint8Array(buf); let off=0; const files={};
+  const dec=new TextDecoder();
+  while(off+30<=u8.length){
+    const sig=view.getUint32(off,true); if(sig!==0x04034b50) break;
+    const comp=view.getUint16(off+8,true); const nameLen=view.getUint16(off+26,true); const extraLen=view.getUint16(off+28,true);
+    const size=view.getUint32(off+18,true); const name=dec.decode(u8.subarray(off+30,off+30+nameLen));
+    const start=off+30+nameLen+extraLen; const data=u8.subarray(start,start+size);
+    if(comp===0) files[name]=data; else if(comp===8) files[name]=await inflateRaw(data); else throw new Error('Unsupported compression');
+    off=start+size;
+  }
+  return files;
+}
+
+async function inflateRaw(data){
+  if(typeof DecompressionStream==='undefined') throw new Error('DecompressionStream unsupported');
+  const ds=new DecompressionStream('deflate-raw');
+  const ab=await new Response(new Blob([data]).stream().pipeThrough(ds)).arrayBuffer();
+  return new Uint8Array(ab);
+}

--- a/cfd_statistics.html
+++ b/cfd_statistics.html
@@ -54,4 +54,5 @@ nav_order: 2
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" onerror="this.onerror=null;this.src='{{ '/assets/js/libs/xlsx.full.min.js' | relative_url }}'"></script>
 <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" onerror="this.onerror=null;this.src='{{ '/assets/js/libs/papaparse.min.js' | relative_url }}'"></script>
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js" onerror="this.onerror=null;this.src='{{ '/assets/js/libs/dayjs.min.js' | relative_url }}'"></script>
+<script src="{{ '/assets/js/simple-xlsx.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/cfd-stat-simple.js' | relative_url }}?v=4"></script>

--- a/rmse_calculator.html
+++ b/rmse_calculator.html
@@ -124,6 +124,7 @@
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" onerror="this.onerror=null;this.src='assets/js/libs/xlsx.full.min.js'"></script>
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" onerror="this.onerror=null;this.src='assets/js/libs/papaparse.min.js'"></script>
     <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js" onerror="this.onerror=null;this.src='assets/js/libs/dayjs.min.js'"></script>
+    <script src="assets/js/simple-xlsx.js"></script>
     <script src="assets/js/rmse-calculator.js"></script>
     <script src="script.js" type="module"></script>
 </body>


### PR DESCRIPTION
## Summary
- provide `simple-xlsx.js` minimal parser using browser `DecompressionStream`
- fallback to `SimpleXLSX` when `XLSX` library is unavailable
- include the parser on CFD statistics and RMSE calculator pages

## Testing
- `python3 -m http.server &` and basic curl checks

------
https://chatgpt.com/codex/tasks/task_e_68513293d2d88333a674600a133c0fbd